### PR TITLE
Small case issue in readme file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Installation
 Add the following entry to ``deps`` the run ``php bin/vendors install``::
 
     [KnpMarkdownBundle]
-        git=http://github.com/knplabs/KnpMarkdownBundle.git
+        git=http://github.com/KnpLabs/KnpMarkdownBundle.git
         target=/bundles/Knp/Bundle/MarkdownBundle
 
     [SonataFormatterBundle]


### PR DESCRIPTION
When the case of the deps code is wrong, the "vendors install" command will fail. Fixed the reference in the readme
