### PR TITLE
Fix requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/framework-bundle": "master-dev",
+        "symfony/framework-bundle": "2.1.*",
         "twig/twig": "*",
         "knplabs/knp-markdown-bundle": "*"
     },


### PR DESCRIPTION
Requiring explicitly branches is not such a great idea for reusable libs like this because it means users are forced to use that, and if there was a 2.1 stable they couldn't even use it. For now this will still install the master branch since it has a 2.1.x-dev alias.
