### PR TITLE
Add form component in the requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,11 @@
     ],
     "require": {
         "php": ">=5.3.2",
+
         "symfony/framework-bundle": "2.1.*",
+        "symfony/form": "2.1.*",
         "twig/twig": "*",
+
         "knplabs/knp-markdown-bundle": "*"
     },
     "autoload": {


### PR DESCRIPTION
The symfony/form package was missing in the requirements in composer.json
