### PR TITLE
Updating FormatterListener

### DIFF
--- a/Form/EventListener/FormatterListener.php
+++ b/Form/EventListener/FormatterListener.php
@@ -48,7 +48,7 @@ class FormatterListener
 
         $format = $event->getForm()->get($this->format)->getData();
         $source = $event->getForm()->get($this->source)->getData();
-        $object = $event->getForm()->getData();
+        $object = $event->getData();
 
         // transform the value
         $target->setValue($object, $this->pool->transform($format, $source));


### PR DESCRIPTION
I had a bug width FormatterBundle and BlockBundle,
When I saved datas,they was saved in database and seems OK in front, but when I edit them, they was always replaced by
**"Insert your custom content here".**

I found that in FormatterListener

```
    $event->getForm()->getData(); 
```

not seems to grab the good values from POST datas. I replaced by 

```
    $event->getData();
```

and now it works
