### PR TITLE
Add CKEditor browsing and uploading medias feature

### DIFF
--- a/Admin/CkeditorAdminExtension.php
+++ b/Admin/CkeditorAdminExtension.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Sonata project.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ * (c) La Coopérative des Tilleuls <contact@les-tilleuls.coop>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\FormatterBundle\Admin;
+
+use Sonata\AdminBundle\Admin\AdminExtension;
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Route\RouteCollection;
+
+/**
+ * Adds browser and upload routes to the Admin
+ *
+ * @author Kévin Dunglas <kevin@les-tilleuls.coop>
+ */
+class CkeditorAdminExtension extends AdminExtension
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function configureRoutes(AdminInterface $admin, RouteCollection $collection)
+    {
+        $collection->add('ckeditor_browser', 'ckeditor_browser', array(
+            '_controller' => 'SonataFormatterBundle:CkeditorAdmin:browser'
+        ));
+
+        $collection->add('ckeditor_upload', 'ckeditor_upload', array(
+            '_controller' => 'SonataFormatterBundle:CkeditorAdmin:upload'
+        ));
+    }
+}

--- a/Controller/CkeditorAdminController.php
+++ b/Controller/CkeditorAdminController.php
@@ -1,0 +1,129 @@
+<?php
+
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\FormatterBundle\Controller;
+
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+use Sonata\MediaBundle\Controller\MediaAdminController as BaseMediaAdminController;
+
+class CkeditorAdminController extends BaseMediaAdminController
+{
+    /**
+     * Returns the response object associated with the browser action
+     *
+     * @return Response
+     *
+     * @throws AccessDeniedException
+     */
+    public function browserAction()
+    {
+        $this->checkIfMediaBundleIsLoaded();
+
+        if (false === $this->admin->isGranted('LIST')) {
+            throw new AccessDeniedException();
+        }
+
+        $datagrid = $this->admin->getDatagrid();
+        $datagrid->setValue('context', null, $this->admin->getPersistentParameter('context'));
+        $datagrid->setValue('providerName', null, $this->admin->getPersistentParameter('provider'));
+
+        $formats = array();
+
+        foreach ($datagrid->getResults() as $media) {
+            $formats[$media->getId()] = $this->get('sonata.media.pool')->getFormatNamesByContext($media->getContext());
+        }
+
+        $formView = $datagrid->getForm()->createView();
+
+        $this->get('twig')->getExtension('form')->renderer->setTheme($formView, $this->admin->getFilterTheme());
+
+        return $this->render($this->getTemplate('browser'), array(
+            'action' => 'browser',
+            'form' => $formView,
+            'datagrid' => $datagrid,
+            'formats' => $formats
+        ));
+    }
+
+    /**
+     * Returns the response object associated with the upload action
+     *
+     * @return Response
+     *
+     * @throws NotFoundHttpException
+     */
+    public function uploadAction()
+    {
+        $this->checkIfMediaBundleIsLoaded();
+
+        if (false === $this->admin->isGranted('CREATE')) {
+            throw new AccessDeniedException();
+        }
+
+        $mediaManager = $this->get('sonata.media.manager.media');
+
+        $request = $this->getRequest();
+        $provider = $request->get('provider');
+        $file = $request->files->get('upload');
+
+        if (!$request->isMethod('POST') || !$provider || null === $file) {
+            throw $this->createNotFoundException();
+        }
+
+        $context = $request->get('context', $this->get('sonata.media.pool')->getDefaultContext());
+
+        $media = $mediaManager->create();
+        $media->setBinaryContent($file);
+
+        $mediaManager->save($media, $context, $provider);
+        $this->admin->createObjectSecurity($media);
+
+        return $this->render($this->getTemplate('upload'), array(
+            'action' => 'list',
+            'object' => $media
+        ));
+    }
+
+    /**
+     * Returns a template
+     *
+     * @param string $name
+     *
+     * @return string
+     */
+    private function getTemplate($name)
+    {
+        $templates = $this->container->getParameter('sonata.formatter.ckeditor.configuration.templates');
+
+        if (isset($templates[$name])) {
+            return $templates[$name];
+        }
+
+        return null;
+    }
+
+    /**
+     * Checks if SonataMediaBundle is loaded otherwise throws an exception
+     *
+     * @throws \RuntimeException
+     */
+    private function checkIfMediaBundleIsLoaded()
+    {
+        $bundles = $this->container->getParameter('kernel.bundles');
+
+        if (!isset($bundles['SonataMediaBundle'])) {
+            throw new \RuntimeException('You cannot use this feature because you have to use SonataMediaBundle');
+        }
+    }
+}

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -2,6 +2,7 @@
 
 namespace Sonata\FormatterBundle\DependencyInjection;
 
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -36,6 +37,32 @@ class Configuration implements ConfigurationInterface
             ->end()
         ;
 
+        $this->addCkeditorSection($rootNode);
+
         return $treeBuilder;
+    }
+
+    /**
+     * Adds CKEditor configuration section to root node configuration
+     *
+     * @param ArrayNodeDefinition $node
+     */
+    private function addCkeditorSection(ArrayNodeDefinition $node)
+    {
+        $node
+            ->children()
+                ->arrayNode('ckeditor')
+                ->addDefaultsIfNotSet()
+                    ->children()
+                        ->arrayNode('templates')
+                            ->addDefaultsIfNotSet()
+                            ->children()
+                                ->scalarNode('browser')->defaultValue('SonataFormatterBundle:Ckeditor:browser.html.twig')->cannotBeEmpty()->end()
+                                ->scalarNode('upload')->defaultValue('SonataFormatterBundle:Ckeditor:upload.html.twig')->cannotBeEmpty()->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
     }
 }

--- a/DependencyInjection/SonataFormatterExtension.php
+++ b/DependencyInjection/SonataFormatterExtension.php
@@ -42,8 +42,13 @@ class SonataFormatterExtension extends Extension
         $loader->load('form.xml');
         
         $bundles = $container->getParameter('kernel.bundles');
+
         if (isset($bundles['SonataBlockBundle'])) {
             $loader->load('block.xml');
+        }
+
+        if (isset($bundles['SonataMediaBundle'])) {
+            $loader->load('ckeditor.xml');
         }
 
         $pool = $container->getDefinition('sonata.formatter.pool');
@@ -57,6 +62,8 @@ class SonataFormatterExtension extends Extension
 
             $pool->addMethodCall('add', array($code, new Reference($configuration['service']), $env));
         }
+
+        $container->setParameter('sonata.formatter.ckeditor.configuration.templates', $config['ckeditor']['templates']);
     }
 
     /**

--- a/Resources/config/ckeditor.xml
+++ b/Resources/config/ckeditor.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="sonata.formatter.ckeditor.extension.class">Sonata\FormatterBundle\Admin\CkeditorAdminExtension</parameter>
+    </parameters>
+
+    <services>
+        <service id="sonata.formatter.ckeditor.extension" class="%sonata.formatter.ckeditor.extension.class%">
+            <tag name="sonata.admin.extension" target="sonata.media.admin.media" />
+        </service>
+    </services>
+</container>

--- a/Resources/config/form.xml
+++ b/Resources/config/form.xml
@@ -10,6 +10,7 @@
 
             <argument type="service" id="sonata.formatter.pool" />
             <argument type="service" id="translator" />
+            <argument type="service" id="ivory_ck_editor.config_manager" />
         </service>
     </services>
 

--- a/Resources/config/twig.xml
+++ b/Resources/config/twig.xml
@@ -18,7 +18,6 @@
         <service id="sonata.formatter.twig.control_flow" class="Sonata\FormatterBundle\Extension\ControlFlowExtension" public="true">
 
         </service>
-
     </services>
 
 </container>

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -14,3 +14,4 @@ Reference Guide
    reference/usage
    reference/formatter_widget
    reference/formatter_block
+   reference/ckeditor_medias

--- a/Resources/doc/reference/ckeditor_medias.rst
+++ b/Resources/doc/reference/ckeditor_medias.rst
@@ -1,0 +1,63 @@
+Use CKEditor to select medias in SonataMediaBundle
+==================================================
+
+When using richhtml formatting option with ``CKEditor``, you can add a feature to select images directly
+from ``SonataMediaBundle`` or even upload new medias from the editor in ``SonataMediaBundle`` and add it to your content.
+
+It can be a quick way for editors to manage medias.
+
+Configuration
+-------------
+
+First of all, you have to define your ``IvoryCKEditorBundle`` (already embedded in ``SonataFormatterBundle``) configurations like this:
+
+.. code-block:: yaml
+
+    ivory_ck_editor:
+        default_config: default
+        configs:
+            default:
+                filebrowserBrowseRoute: admin_sonata_media_media_ckeditor_browser
+                filebrowserImageBrowseRoute: admin_sonata_media_media_ckeditor_browser
+                # Display images by default when clicking the image dialog browse button
+                filebrowserImageBrowseRouteParameters:
+                    provider: sonata.media.provider.image
+                filebrowserUploadRoute: admin_sonata_media_media_ckeditor_upload
+                filebrowserUploadRouteParameters:
+                    provider: sonata.media.provider.file
+                # Upload file as image when sending a file from the image dialog
+                filebrowserImageUploadRoute: admin_sonata_media_media_ckeditor_upload
+                filebrowserImageUploadRouteParameters:
+                    provider: sonata.media.provider.image
+                    context: my-context # Optional, to upload in a custom context
+
+You can provide custom routes and a custom context to match your needs.
+
+Second step is optional but you can also define some custom browsing and upload templates with the following configuration:
+
+.. code-block:: yaml
+
+  # app/config/config.yml
+
+  sonata_formatter:
+      ckeditor:
+          templates:
+              browser: 'SonataFormatterBundle:Ckeditor:browser.html.twig'
+              upload: 'SonataFormatterBundle:Ckeditor:upload.html.twig'
+
+Last step takes place in your admin class, you just have to specify the ``ckeditor_context`` parameter.
+
+Here is an example:
+
+.. code-block:: php
+
+    $formMapper->add('shortDescription', 'sonata_formatter_type', array(
+        'source_field'         => 'rawDescription',
+        'source_field_options' => array('attr' => array('class' => 'span10', 'rows' => 20)),
+        'format_field'         => 'descriptionFormatter',
+        'target_field'         => 'description',
+        'ckeditor_context'     => 'default',
+        'event_dispatcher'     => $formMapper->getFormBuilder()->getEventDispatcher()
+    ));
+
+And that's it, enjoy browsing and uploading your medias using ``SonataMediaBundle``.

--- a/Resources/doc/reference/formatter_widget.rst
+++ b/Resources/doc/reference/formatter_widget.rst
@@ -69,6 +69,10 @@ the ``sonata_formatter_type_selector`` takes 2 options:
  - ``source_field_options``: the source field options  (optional)
  - ``target_field``: the entity's final field with the transformed data
 
+Additionally, the following option can be added to give CKEditor a context in order to customize routes used to browser and upload medias:
+
+- ``ckeditor_context``: the CKEditor configuration context name (optional)
+
 If you stop here, the most interesting part will not be present, let's edit some configuration files.
 
 .. note::

--- a/Resources/views/Ckeditor/browser.html.twig
+++ b/Resources/views/Ckeditor/browser.html.twig
@@ -1,0 +1,241 @@
+{% extends 'SonataAdminBundle::layout.html.twig' %}
+
+{% set ckParameters = {'CKEditor': app.request.get('CKEditor'), 'CKEditorFuncNum': app.request.get('CKEditorFuncNum')} %}
+
+{% block javascripts %}
+    {{ parent() }}
+
+    <script>
+        $(function () {
+            $(".select").click(function (e) {
+                e.preventDefault();
+                window.opener.CKEDITOR.tools.callFunction({{ app.request.get('CKEditorFuncNum')|escape('js') }}, $(this).attr("href"));
+                window.close();
+            });
+        });
+    </script>
+{% endblock %}
+
+{% block sonata_nav %}{% endblock %}
+{% block sonata_breadcrumb %}{% endblock %}
+
+{% block preview %}
+
+    <ul class="nav nav-pills">
+        <li><a><strong>{{ "label.select_context"|trans({}, 'SonataMediaBundle') }}</strong></a></li>
+        {% for name, context in media_pool.contexts %}
+            {% if context.providers|length == 0 %}
+                {% set urlParams = {'context' : name}|merge(ckParameters) %}
+            {% else %}
+                {% set urlParams = {'context' : name, 'provider' : context.providers[0]}|merge(ckParameters) %}
+            {% endif %}
+
+            {% if name == persistent_parameters.context %}
+                <li class="active"><a href="{{ admin.generateUrl('ckeditor_browser', urlParams) }}">{{ name|trans({}, 'SonataMediaBundle') }}</a></li>
+            {% else %}
+                <li><a href="{{ admin.generateUrl('ckeditor_browser', urlParams) }}">{{ name|trans({}, 'SonataMediaBundle') }}</a></li>
+            {% endif %}
+        {% endfor %}
+
+        {% set providers = media_pool.getProviderNamesByContext(persistent_parameters.context) %}
+
+        {% if providers|length > 1 %}
+            <li><a><strong>{{ "label.select_provider"|trans({}, 'SonataMediaBundle') }}</strong></a></li>
+
+            {% if not persistent_parameters.provider %}
+                <li class="active"><a href="{{ admin.generateUrl('ckeditor_browser', {'context': persistent_parameters.context, 'provider': null}|merge(ckParameters)) }}">{{ "link.all_providers"|trans({}, 'SonataMediaBundle') }}</a></li>
+            {% else %}
+                <li><a href="{{ admin.generateUrl('ckeditor_browser', {'context': persistent_parameters.context, 'provider': null}|merge(ckParameters)) }}">{{ "link.all_providers"|trans({}, 'SonataMediaBundle') }}</a></li>
+            {% endif %}
+
+            {% for provider_name in providers %}
+                {% if persistent_parameters.provider == provider_name%}
+                    <li class="active"><a href="{{ admin.generateUrl('ckeditor_browser', {'context': persistent_parameters.context, 'provider': provider_name}|merge(ckParameters)) }}">{{ provider_name|trans({}, 'SonataMediaBundle') }}</a></li>
+                {% else %}
+                    <li><a href="{{ admin.generateUrl('ckeditor_browser', {'context': persistent_parameters.context, 'provider': provider_name}|merge(ckParameters)) }}">{{ provider_name|trans({}, 'SonataMediaBundle') }}</a></li>
+                {% endif %}
+            {% endfor %}
+        {% endif %}
+    </ul>
+
+{% endblock %}
+
+{% block list_table %}
+    {% set batchactions = admin.batchactions %}
+    {% if admin.datagrid.results|length > 0 %}
+        <table class="table table-bordered table-striped">
+            {% block table_header %}
+                <thead>
+                <tr class="sonata-ba-list-field-header">
+                    {% for field_description in admin.list.elements %}
+                        {% if field_description.getOption('code') == '_batch' or field_description.name == '_action' %}
+                            {# Disable batch and actions #}
+                        {% else %}
+                            {% set sortable = false %}
+                            {% if field_description.options.sortable is defined and field_description.options.sortable%}
+                                {% set sortable             = true %}
+                                {% set current              = admin.datagrid.values._sort_by == field_description %}
+                                {% set sort_parameters      = admin.modelmanager.sortparameters(field_description, admin.datagrid)|merge(ckParameters) %}
+                                {% set sort_active_class    = current ? 'sonata-ba-list-field-order-active' : '' %}
+                                {% set sort_by              = current ? admin.datagrid.values._sort_order : field_description.options._sort_order %}
+                            {% endif %}
+
+                            {% spaceless %}
+                                <th class="sonata-ba-list-field-header-{{ field_description.type}} {% if sortable %} sonata-ba-list-field-header-order-{{ sort_by|lower }} {{ sort_active_class }}{% endif %}">
+                                    {% if sortable %}<a href="{{ admin.generateUrl('ckeditor_browser', sort_parameters) }}">{% endif %}
+                                        {{ admin.trans(field_description.label) }}
+                                        {% if sortable %}</a>{% endif %}
+                                </th>
+                            {% endspaceless %}
+                        {% endif %}
+                    {% endfor %}
+                </tr>
+                </thead>
+            {% endblock %}
+
+            {% block table_body %}
+                <tbody>
+                {% for object in admin.datagrid.results %}
+                    <tr>
+                        {% for field_description in admin.list.elements %}
+                            {% if field_description.getOption('code') == '_batch' or field_description.name == '_action' %}
+                                {# Disable batch and actions #}
+                            {% elseif field_description.name == 'custom' %}
+                                <td>
+                                    <div>
+                                        <a href="{% path object, 'reference' %}" class="select" style="float: left; margin-right: 6px;">{% thumbnail object, 'admin' with {'width': 75, 'height': 60} %}</a>
+
+                                        <strong><a href="{% path object, 'reference' %}" class="select">{{ object.name }}</a></strong> <br />
+                                        {{ object.providerName|trans({}, 'SonataMediaBundle') }}{% if object.width %}: {{ object.width }}{% if object.height %}x{{ object.height }}{% endif %}px{% endif %}
+
+                                        {% if formats[object.id]|length > 0 %}
+                                            - {{ 'title.formats'|trans({}, 'SonataMediaBundle') }}:
+                                            {% for name, format in formats[object.id] %}
+                                                <a href="{% path object, name %}" class="select">{{ name }}</a> {% if format.width %}({{ format.width }}{% if format.height %}x{{ format.height }}{% endif %}px){% endif %}
+                                            {% endfor %}
+                                        {% endif %}
+                                        <br />
+                                    </div>
+                                </td>
+                            {% else %}
+                                {{ object|render_list_element(field_description) }}
+                            {% endif %}
+                        {% endfor %}
+                    </tr>
+                {% endfor %}
+                </tbody>
+            {% endblock %}
+
+            {% block table_footer %}
+                <tr>
+                    <th colspan="{{ admin.list.elements|length - 2 }}">
+                        <div class="form-inline">
+                            <div class="pull-right">
+                                {% block pager_results %}
+                                    {% block num_pages %}
+                                        {{ admin.datagrid.pager.page }} / {{ admin.datagrid.pager.lastpage }}
+                                        &nbsp;-&nbsp;
+                                    {% endblock %}
+
+                                    {% block num_results %}
+                                        {% transchoice admin.datagrid.pager.nbresults with {'%count%': admin.datagrid.pager.nbresults} from 'SonataAdminBundle' %}list_results_count{% endtranschoice %}
+                                        &nbsp;-&nbsp;
+                                    {% endblock %}
+
+                                    {% block max_per_page %}
+                                        <label class="control-label" for="{{ admin.uniqid }}_per_page">{% trans from 'SonataAdminBundle' %}label_per_page{% endtrans %}</label>
+                                        <select class="per-page small" id="{{ admin.uniqid }}_per_page" style="width: auto; height: auto">
+                                            {% for per_page in admin.getperpageoptions %}
+                                                <option {% if per_page == admin.datagrid.pager.maxperpage %}selected="selected"{% endif %} value="{{ admin.generateUrl('ckeditor_browser', {'filter': admin.datagrid.values|merge({'_per_page': per_page})}|merge(ckParameters)) }}">
+                                                    {{ per_page }}
+                                                </option>
+                                            {% endfor %}
+                                        </select>
+                                    {% endblock %}
+                                {% endblock %}
+                            </div>
+                        </div>
+                    </th>
+                </tr>
+
+                {% block pager_links %}
+                    {% if admin.datagrid.pager.haveToPaginate() %}
+                        <tr>
+                            <td colspan="{{ admin.list.elements|length }}">
+                                <div class="pagination pagination-centered">
+                                    <ul>
+                                        {% if admin.datagrid.pager.page > 2  %}
+                                            <li><a href="{{ admin.generateUrl('ckeditor_browser', admin.modelmanager.paginationparameters(admin.datagrid, 1)|merge(ckParameters)) }}" title="{{ 'link_first_pager'|trans({}, 'SonataAdminBundle') }}">&laquo;</a></li>
+                                        {% endif %}
+
+                                        {% if admin.datagrid.pager.page != admin.datagrid.pager.previouspage %}
+                                            <li><a href="{{ admin.generateUrl('ckeditor_browser', admin.modelmanager.paginationparameters(admin.datagrid, admin.datagrid.pager.previouspage)|merge(ckParameters)) }}" title="{{ 'link_previous_pager'|trans({}, 'SonataAdminBundle') }}">&lsaquo;</a></li>
+                                        {% endif %}
+
+                                        {# Set the number of pages to display in the pager #}
+                                        {% for page in admin.datagrid.pager.getLinks() %}
+                                            {% if page == admin.datagrid.pager.page %}
+                                                <li class="active"><a href="{{ admin.generateUrl('ckeditor_browser', admin.modelmanager.paginationparameters(admin.datagrid, page)|merge(ckParameters)) }}">{{ page }}</a></li>
+                                            {% else %}
+                                                <li><a href="{{ admin.generateUrl('ckeditor_browser', admin.modelmanager.paginationparameters(admin.datagrid, page)|merge(ckParameters)) }}">{{ page }}</a></li>
+                                            {% endif %}
+                                        {% endfor %}
+
+                                        {% if admin.datagrid.pager.page != admin.datagrid.pager.nextpage %}
+                                            <li><a href="{{ admin.generateUrl('ckeditor_browser', admin.modelmanager.paginationparameters(admin.datagrid, admin.datagrid.pager.nextpage)|merge(ckParameters)) }}" title="{{ 'link_next_pager'|trans({}, 'SonataAdminBundle') }}">&rsaquo;</a></li>
+                                        {% endif %}
+
+                                        {% if admin.datagrid.pager.page != admin.datagrid.pager.lastpage and admin.datagrid.pager.lastpage != admin.datagrid.pager.nextpage %}
+                                            <li><a href="{{ admin.generateUrl('ckeditor_browser', admin.modelmanager.paginationparameters(admin.datagrid, admin.datagrid.pager.lastpage)|merge(ckParameters)) }}" title="{{ 'link_last_pager'|trans({}, 'SonataAdminBundle') }}">&raquo;</a></li>
+                                        {% endif %}
+                                    </ul>
+                                </div>
+                            </td>
+                        </tr>
+
+                    {% endif %}
+                {% endblock %}
+
+            {% endblock %}
+        </table>
+    {% else %}
+        <p class="notice">
+            {{ 'no_result'|trans({}, 'SonataAdminBundle') }}
+        </p>
+    {% endif %}
+{% endblock %}
+
+{% block list_filters %}
+    {% if admin.datagrid.filters %}
+        <form class="sonata-filter-form {{ admin.isChild and 1 == admin.datagrid.filters|length ? 'hide' : '' }}" action="{{ admin.generateUrl('ckeditor_browser') }}" method="GET">
+            <fieldset class="filter_legend">
+                <legend class="filter_legend {{ admin.datagrid.hasActiveFilters ? 'active' : 'inactive' }}">{{ 'label_filters'|trans({}, 'SonataAdminBundle') }}</legend>
+
+                <div class="filter_container {{ admin.datagrid.hasActiveFilters ? 'active' : 'inactive' }}">
+                    <div>
+                        {% for filter in admin.datagrid.filters %}
+                            <div class="clearfix">
+                                <label for="{{ form.children[filter.formName].children['value'].vars.id }}">{{ admin.trans(filter.label) }}</label>
+                                {{ form_widget(form.children[filter.formName].children['type'], {'attr': {'class': 'span8 sonata-filter-option'}}) }}
+                                {{ form_widget(form.children[filter.formName].children['value'], {'attr': {'class': 'span8'}}) }}
+                            </div>
+                        {% endfor %}
+                    </div>
+
+                    <input type="hidden" name="filter[_page]" id="filter__page" value="1" />
+
+                    {% set foo = form.children['_page'].setRendered() %}
+                    {{ form_rest(form) }}
+
+                    <input type="submit" class="btn btn-primary" value="{{ 'btn_filter'|trans({}, 'SonataAdminBundle') }}" />
+
+                    <a class="btn" href="{{ admin.generateUrl('ckeditor_browser', {filters: 'reset'}|merge(ckParameters)) }}">{{ 'link_reset_filter'|trans({}, 'SonataAdminBundle') }}</a>
+                </div>
+
+                {% for paramKey, paramValue in admin.persistentParameters|merge(ckParameters) %}
+                    <input type="hidden" name="{{ paramKey }}" value="{{ paramValue }}" />
+                {% endfor %}
+            </fieldset>
+        </form>
+    {% endif %}
+{% endblock %}

--- a/Resources/views/Ckeditor/upload.html.twig
+++ b/Resources/views/Ckeditor/upload.html.twig
@@ -1,0 +1,1 @@
+<script>window.parent.CKEDITOR.tools.callFunction({{ app.request.get('CKEditorFuncNum')|escape('js') }}, "{% path object, 'reference'|escape('js') %}");</script>

--- a/Resources/views/Form/formatter.html.twig
+++ b/Resources/views/Form/formatter.html.twig
@@ -41,11 +41,7 @@
                         appendClass = 'html';
                         break;
                     case 'richhtml':
-                        {{ source_id }}_rich_instance = CKEDITOR.replace('{{ form.children[source_field].vars.id }}', {
-                            toolbar: [
-                                {{ ckeditor_toolbar_icons|raw }}
-                            ]
-                        });
+                        {{ source_id }}_rich_instance = {{ ckeditor_replace(form.children[source_field].vars.id, ckeditor_configuration) }};
                 }
 
                 var parent = elms.parents('div.markItUp');

--- a/Tests/Formatter/RawFormatterTest.php
+++ b/Tests/Formatter/RawFormatterTest.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ * This file is part of the Sonata project.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\FormatterBundle\Tests\Formatter;
+
+use Sonata\FormatterBundle\Formatter\RawFormatter;
+
+class RawFormatterTest extends \PHPUnit_Framework_TestCase
+{
+    public function testFormatter()
+    {
+        $formatter = new RawFormatter();
+
+        $this->assertEquals("Salut", $formatter->transform("Salut"));
+        $this->assertEquals("<p>Salut<br />Ca va ?</p>", $formatter->transform("<p>Salut<br />Ca va ?</p>"));
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "twig/twig": "*",
         "knplabs/knp-markdown-bundle": "1.2.*@dev",
         "sonata-project/markitup-bundle": "~2.1",
-        "egeloen/ckeditor-bundle": "2.*",
+        "egeloen/ckeditor-bundle": "~2.2",
         "sonata-project/block-bundle": "~2.2,>=2.2.1",
         "sonata-project/core-bundle": "~2.2"
     },


### PR DESCRIPTION
I've integrated the way to browse and upload medias in `SonataMediaBundle` used by the following bundle: https://github.com/coopTilleuls/CoopTilleulsCKEditorSonataMediaBundle.

For more information, see issue: https://github.com/coopTilleuls/CoopTilleulsCKEditorSonataMediaBundle/issues/1

![capture decran 2014-01-29 a 12 28 07](https://f.cloud.github.com/assets/103900/2028922/83d1ea38-88d8-11e3-87af-3514e4c0a462.png)

I've added a new documentation entry named "Use CKEditor to select medias in SonataMediaBundle" in this Formatter bundle to explain how to configure.

Have you got some comments?

Thank you for your work @dunglas

TODO:
- [x] waiting @dunglas feedback on the header issue
- [x] waiting @egeloen if CKEditorBundle can be refactored a bit to avoid the scope `request`
- [x] waiting for https://github.com/egeloen/IvoryCKEditorBundle/pull/85
