### PR TITLE
Wrong default SonataAdminBundle layout name

### DIFF
--- a/Resources/views/Ckeditor/browser.html.twig
+++ b/Resources/views/Ckeditor/browser.html.twig
@@ -1,4 +1,4 @@
-{% extends 'SonataAdminBundle::layout.html.twig' %}
+{% extends 'SonataAdminBundle::standard_layout.html.twig' %}
 
 {% set ckParameters = {'CKEditor': app.request.get('CKEditor'), 'CKEditorFuncNum': app.request.get('CKEditorFuncNum')} %}
 


### PR DESCRIPTION
It bring up an error in my project, but that seems too easy =)
SonataAdminBundle views : https://github.com/sonata-project/SonataAdminBundle/tree/master/Resources/views
