### PR TITLE
Update FormatterType.php

### DIFF
--- a/Form/Type/FormatterType.php
+++ b/Form/Type/FormatterType.php
@@ -171,7 +171,7 @@ class FormatterType extends AbstractType
                  array('Maximize', 'Source')
             ),
             'ckeditor_basepath'         => 'bundles/sonataformatter/vendor/ckeditor',
-            'ckeditor_context'          => null,
+            'ckeditor_context'          => 'default',
             'format_field_options'      => array(
                 'choices'               => function (Options $options) use ($pool, $translator) {
                     $formatters = array();


### PR DESCRIPTION
To avoid to override the FormatterType.php just for this property (ckeditor_context). Even without a default configuration in sonata_formatter.yml seems work perfectly.