### PR TITLE
Implement possibility to add plugins in CKEditor

### DIFF
--- a/Form/Type/FormatterType.php
+++ b/Form/Type/FormatterType.php
@@ -143,6 +143,9 @@ class FormatterType extends AbstractType
             $ckeditorConfiguration = array_merge($ckeditorConfiguration, $contextConfig);
         }
 
+        $view->vars['ckeditor_plugins']  = $options['ckeditor_plugins'];
+        $ckeditorConfiguration['extraPlugins'] = implode(',', array_keys($options['ckeditor_plugins']));
+
         $view->vars['ckeditor_configuration'] = $ckeditorConfiguration;
         $view->vars['ckeditor_basepath'] = $options['ckeditor_basepath'];
 
@@ -175,6 +178,7 @@ class FormatterType extends AbstractType
                  '-', 'Image', 'Link', 'Unlink', 'Table'),
                  array('Maximize', 'Source')
             ),
+            'ckeditor_plugins'          => array(),
             'ckeditor_basepath'         => 'bundles/sonataformatter/vendor/ckeditor',
             'ckeditor_context'          => null,
             'format_field_options'      => array(

--- a/Resources/doc/reference/formatter_widget.rst
+++ b/Resources/doc/reference/formatter_widget.rst
@@ -94,6 +94,21 @@ Here is the default `CKEditor` custom tooolbar configuration, you can tweak:
         2 => array('Maximize', 'Source')
     );
 
+You can also implement external plugins:
+
+.. code-block:: php
+
+    <?php
+
+    $formMapper->add('content', 'sonata_formatter_type', [
+        'ckeditor_plugins' => array(
+            'pbckcode' => array(
+                'path' => '/bundles/app/pbckcode/',
+                'file' => 'plugin.js' // Optional if the default filename is plugin.js
+            )
+        )
+    ])
+
 If you stop here, the most interesting part will not be present. Let's edit some configuration files.
 
 .. note::

--- a/Resources/views/Form/formatter.html.twig
+++ b/Resources/views/Form/formatter.html.twig
@@ -49,6 +49,14 @@
                         appendClass = 'html';
                         break;
                     case 'richhtml':
+                        {%- for name, plugin in ckeditor_plugins if ckeditor_plugins is defined -%}
+                            CKEDITOR.plugins.addExternal('{{ name }}', '{{ plugin.path }}',
+                                    {%- if plugin.file is defined -%}
+                                        '{{ plugin.file }}'
+                                    {%- else -%}
+                                        'plugin.js'
+                                    {%- endif -%});
+                        {% endfor %}
                         {{ source_id }}_rich_instance = {{ ckeditor_replace(form.children[source_field].vars.id, ckeditor_configuration) }};
 
                 }


### PR DESCRIPTION
Proposal for an implementation of external plugins.

Example:
```php
$formMapper->add('content', 'sonata_formatter_type', [
    'ckeditor_plugins' => array(
        'pbckcode' => array(
            'path' => '/bundles/app/pbckcode/',
            'file' => 'plugin.js' // Optional if the default filename is plugin.js
        )
    )
])
```