### PR TITLE
Use default ckeditor config for sonata formatter type if provided

### DIFF
--- a/Form/Type/FormatterType.php
+++ b/Form/Type/FormatterType.php
@@ -129,9 +129,14 @@ class FormatterType extends AbstractType
         }
         $view->vars['format_field_options'] = $options['format_field_options'];
 
-        $ckeditorConfiguration = array(
-            'toolbar'       => array_values($options['ckeditor_toolbar_icons']),
-        );
+        $defaultConfig = $this->configManager->getDefaultConfig();
+        if($this->configManager->hasConfig($defaultConfig)){
+            $ckeditorConfiguration = $this->configManager->getConfig($defaultConfig);
+        } else {
+            $ckeditorConfiguration = array(
+                'toolbar'       => array_values($options['ckeditor_toolbar_icons']),
+            );
+        }
 
         if ($options['ckeditor_context']) {
             $contextConfig = $this->configManager->getConfig($options['ckeditor_context']);


### PR DESCRIPTION
For example the page composer uses the sonata_formatter_type, which will load a default toolbar for the ckeditor.

If your ivory_ckeditor config specifies a default config it will now load the default. Bundles like news will keep working like before because they specify the ckeditor_context.