### PR TITLE
Fixed JS error when switching formatter from ckeditor

### DIFF
--- a/Resources/views/Form/formatter.html.twig
+++ b/Resources/views/Form/formatter.html.twig
@@ -20,8 +20,12 @@
                 return;
             }
 
+            var isInstanceActive = isInstanceActive || function(instance){
+                return instance && instance.status !== "destroyed";
+            };
+
             jQuery('#{{ form.children[format_field].vars.id }}').parents("form").on('click', function(event) {
-                if ({{ source_id }}_rich_instance) {
+                if (isInstanceActive({{ source_id }}_rich_instance)) {
                     {{ source_id }}_rich_instance.updateElement();
                 }
             });
@@ -29,7 +33,7 @@
             jQuery('#{{ form.children[format_field].vars.id }}').change(function(event) {
                 var elms = jQuery('#{{ form.children[source_field].vars.id }}');
                 elms.markItUpRemove();
-                if ({{ source_id }}_rich_instance) {
+                if (isInstanceActive({{ source_id }}_rich_instance)) {
                     {{ source_id }}_rich_instance.destroy();
                 }
 


### PR DESCRIPTION
When switching from ckeditor, a JS error is thrown as  `{{ source_id }}_rich_instance` is not destroyed, only unbound.

This fix checks the status of `{{ source_id }}_rich_instance` to check the instance has been destroyed