### PR TITLE
[NO-TICKET]: Allow [formatter && media] bundle to be used without cla…

### DIFF
--- a/Controller/CkeditorAdminController.php
+++ b/Controller/CkeditorAdminController.php
@@ -48,9 +48,12 @@ class CkeditorAdminController extends BaseMediaAdminController
         $datagrid->setValue('providerName', null, $this->admin->getPersistentParameter('provider'));
 
         // retrieve the main category for the tree view
-        $category = $this->container->get('sonata.classification.manager.category')->getRootCategory($context);
+        $category = null;
+        if ($this->container->has('sonata.media.manager.category')) {
+            $category = $this->container->get('sonata.media.manager.category')->getRootCategory($context);
+        }
 
-        if (!$filters) {
+        if (!$filters && null !== $category) {
             $datagrid->setValue('category', null, $category->getId());
         }
 

--- a/Resources/views/Ckeditor/browser.html.twig
+++ b/Resources/views/Ckeditor/browser.html.twig
@@ -69,7 +69,9 @@ file that was distributed with this source code.
 
 {% block list_table %}
     <div class="col-xs-6 col-md-3">
-        {{ tree.navigate_child([root_category], admin, true, datagrid.values['category']['value'], 1) }}
+        {% if root_category is not null %}
+            {{ tree.navigate_child([root_category], admin, true, datagrid.values['category']['value'], 1) }}
+        {% endif %}
     </div>
 
     <div class="col-xs-12 col-md-9">


### PR DESCRIPTION
[NO-TICKET]: Allow [formatter && media] bundle to be used without classification bundle

Q                         | A
---------------------- | ---
Bug fix?               | yes
New feature?      | no
BC breaks?         | no
Deprecations?    | no
Tests pass?        | yes
Fixed tickets       | 
License               | MIT
Doc PR               | no

this PR should only be merged after this >> https://github.com/sonata-project/SonataMediaBundle/pull/794