### PR TITLE
[UPT] CKEditor dependency to ~3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ A [BC BREAK] means the update will break the project for many reasons:
 * new dependencies
 * class refactoring
 
+### 2015-10-05
+
+* Update [IvoryCKEditorBundle](https://github.com/egeloen/IvoryCKEditorBundle) to version 3.x.
+
 ### 2014-09-01
 
 * [BC BREAK] Dependency to SonataMarkItUpBundle has been set to require-dev only. You'll need to update your assets path as follows:

--- a/Resources/config/twig.xml
+++ b/Resources/config/twig.xml
@@ -18,6 +18,12 @@
         <service id="sonata.formatter.twig.control_flow" class="Sonata\FormatterBundle\Extension\ControlFlowExtension" public="true">
 
         </service>
+
+        <!--Bridge to keep BC between 2.x and 3.x-->
+        <service id="sonata.formatter.twig.ck_editor" class="Sonata\FormatterBundle\Twig\Extension\CKEditorExtension">
+            <argument type="service" id="ivory_ck_editor.templating.helper" />
+            <tag name="twig.extension" />
+        </service>
     </services>
 
 </container>

--- a/Resources/views/Form/formatter.html.twig
+++ b/Resources/views/Form/formatter.html.twig
@@ -54,8 +54,9 @@
                         appendClass = 'html';
                         break;
                     case 'richhtml':
-                        {{ source_id }}_rich_instance = {{ ckeditor_replace(form.children[source_field].vars.id, ckeditor_configuration) }};
-
+                        {{ source_id }}_rich_instance = {{
+                            ckeditor_widget(form.children[source_field].vars.id, ckeditor_configuration)
+                        }};
                 }
 
                 var parent = elms.parents('div.markItUp');
@@ -98,7 +99,7 @@
             {% elseif format == 'rawhtml' %}
                 elms.markItUp(markitup_sonataHtmlSettings);
             {% elseif format == 'richhtml' %}
-                {{ ckeditor_replace(form.vars.id, ckeditor_configuration) }};
+                {{ ckeditor_widget(form.vars.id, ckeditor_configuration) }};
             {% endif %}
 
             var parent = elms.parents('div.markItUp');

--- a/Twig/Extension/CKEditorExtension.php
+++ b/Twig/Extension/CKEditorExtension.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\FormatterBundle\Twig\Extension;
+
+use Ivory\CKEditorBundle\Templating\CKEditorHelper;
+
+/**
+ * @author Marodon Jérémy <marodon.jeremy@gmail.com>
+ */
+class CKEditorExtension extends \Twig_Extension
+{
+    /**
+     * @var CKEditorHelper
+     */
+    private $helper;
+
+    /**
+     * Creates a CKEditor extension bridge for BC.
+     *
+     * @param CKEditorHelper $helper The CKEditor helper.
+     */
+    public function __construct(CKEditorHelper $helper)
+    {
+        $this->helper = $helper;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFunctions()
+    {
+        $options = array('is_safe' => array('html'));
+
+        return array(
+            new \Twig_SimpleFunction('ckeditor_replace', array($this, 'renderReplace'), $options),
+        );
+    }
+
+    /**
+     * @param string $identifier The identifier.
+     * @param array  $config     The config.
+     *
+     * @return string The rendered replace.
+     */
+    public function renderReplace($identifier, array $config)
+    {
+        @trigger_error('The ckeditor_replace twig function is now deprecated
+        and will be removed in 3.0. Use ckeditor_widget instead.', E_USER_DEPRECATED);
+
+        return $this->helper->renderWidget($identifier, $config);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'ck_editor';
+    }
+}

--- a/UPGRADE-2.4.md
+++ b/UPGRADE-2.4.md
@@ -1,0 +1,14 @@
+UPGRADE FROM 2.3 to 2.4
+=======================
+
+Update [IvoryCKEditorBundle](https://github.com/egeloen/IvoryCKEditorBundle) to version 3.x.
+
+The old ```{{ ckeditor_replace() }}``` twig function has been replaced by ```{{ckeditor_widget() }}```.
+
+[BC] is kept due to a CKEditorExtension, which bridge the old tag ```{{ckeditor_replace() }}``` 
+to the new helper method `renderWidget`.
+
+This introduce the new `inline` option of CKEditor plugin.
+
+All related changes are available here [IvoryCKEditorUPGRADE]
+(https://github.com/egeloen/IvoryCKEditorBundle/blob/master/UPGRADE.md#25-to-30)

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "symfony/property-access": "~2.3|~3.0",
         "twig/twig": "~1.12",
         "knplabs/knp-markdown-bundle": "~1.4",
-        "egeloen/ckeditor-bundle": "~2.2",
+        "egeloen/ckeditor-bundle": "^2.2|^3.0",
         "sonata-project/block-bundle": "~2.2,>=2.2.1",
         "sonata-project/core-bundle": "~2.3,>=2.3.1"
     },


### PR DESCRIPTION
Upgrade `egeloen/ckeditor-bundle` to new major ~3.0

It's BC break, cause the `ckeditor_replace` tag has been renamed, so projects where the template `formatter.html.twig` has been overridden must be updated.

IMO sadly this commit can't be add to 2.3.x