### PR TITLE
[UPT] Gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,6 @@
-.idea
-.DS_Store
 build
 phpunit.xml
 Resources/doc/_build/*
-nbproject
 coverage
 composer.lock
 vendor


### PR DESCRIPTION
This folders mustn't be added on the .gitignore of the project, they're relative to the user environnement. Best practices advise to add the configuration of the user environnement in its own `.gitignore_global`.