### PR TITLE
remove deprecated initRuntime method from twig extension, and remove unused instance variable for environment

### DIFF
--- a/Twig/Extension/TextFormatterExtension.php
+++ b/Twig/Extension/TextFormatterExtension.php
@@ -24,24 +24,11 @@ class TextFormatterExtension extends \Twig_Extension implements \Twig_Extension_
     protected $pool;
 
     /**
-     * @var \Twig_Environment
-     */
-    protected $environment;
-
-    /**
      * @param Pool $pool
      */
     public function __construct(Pool $pool)
     {
         $this->pool = $pool;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function initRuntime(\Twig_Environment $environment)
-    {
-        $this->environment = $environment;
     }
 
     /**


### PR DESCRIPTION
Changes for compatibility with Twig 2.

There's only a danger here if someone has subclassed this extension class instead of using it directly.