### PR TITLE
Remove unused Twig_Environment

### DIFF
--- a/Twig/Extension/TextFormatterExtension.php
+++ b/Twig/Extension/TextFormatterExtension.php
@@ -16,7 +16,7 @@ use Sonata\FormatterBundle\Formatter\Pool;
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class TextFormatterExtension extends \Twig_Extension implements \Twig_Extension_InitRuntimeInterface
+class TextFormatterExtension extends \Twig_Extension
 {
     /**
      * @var Pool
@@ -24,24 +24,11 @@ class TextFormatterExtension extends \Twig_Extension implements \Twig_Extension_
     protected $pool;
 
     /**
-     * @var \Twig_Environment
-     */
-    protected $environment;
-
-    /**
      * @param Pool $pool
      */
     public function __construct(Pool $pool)
     {
         $this->pool = $pool;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function initRuntime(\Twig_Environment $environment)
-    {
-        $this->environment = $environment;
     }
 
     /**


### PR DESCRIPTION
Using the `Twig_Extension_InitRuntimeInterface` is not recommended, since the `transform` method is not actually using the `Twig_Environment` Im not sure why its needed? I can add it back via the preferred method of through the options though if you explain the reason for keeping it. 

- [ ] change the unit tests