### PR TITLE
remove deprecated initRuntime method from twig extension, and remove …

### DIFF
--- a/Twig/Extension/TextFormatterExtension.php
+++ b/Twig/Extension/TextFormatterExtension.php
@@ -26,14 +26,6 @@ class TextFormatterExtension extends \Twig_Extension
     }
 
     /**
-     * {@inheritdoc}
-     */
-    public function initRuntime(\Twig_Environment $environment)
-    {
-        $this->environment = $environment;
-    }
-
-    /**
      * Returns the token parser instance to add to the existing list.
      *
      * @return array An array of Twig_TokenParser instances


### PR DESCRIPTION
…unused instance variable for environment

This is the same change as #130, but applied against the 2.3 branch.