### PR TITLE
CKEditor configuration and simple formatter type

### DIFF
--- a/Form/Type/SimpleFormatterType.php
+++ b/Form/Type/SimpleFormatterType.php
@@ -40,9 +40,17 @@ class SimpleFormatterType extends AbstractType
      */
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
-        $ckeditorConfiguration = array(
-            'toolbar' => array_values($options['ckeditor_toolbar_icons']),
-        );
+        $defaultConfig = $this->configManager->getDefaultConfig();
+
+        if ($this->configManager->hasConfig($defaultConfig)) {
+            $ckeditorConfiguration = $this->configManager->getConfig($defaultConfig);
+        } else {
+            $ckeditorConfiguration = array();
+        }
+
+        if (!array_key_exists('toolbar', $ckeditorConfiguration)) {
+            $ckeditorConfiguration['toolbar'] = array_values($options['ckeditor_toolbar_icons']);
+        }
 
         if ($options['ckeditor_context']) {
             $contextConfig = $this->configManager->getConfig($options['ckeditor_context']);


### PR DESCRIPTION
The simple formatter type was not using ckeditor configuration and therefore all filebrowser* parameters were lost.

This PR fixes this problem.