### PR TITLE
Do not overwrite the format provided by the user with the default format

### DIFF
--- a/Form/Type/FormatterType.php
+++ b/Form/Type/FormatterType.php
@@ -67,7 +67,10 @@ class FormatterType extends AbstractType
             $options['format_field_options']['property_path'] = $formatField;
         }
 
-        $options['format_field_options']['data'] = $this->pool->getDefaultFormatter();
+        if (!array_key_exists('data', $options['format_field_options']) ||
+             !array_key_exists($options['format_field_options']['data'], $this->pool->getFormatters())) {
+            $options['format_field_options']['data'] = $this->pool->getDefaultFormatter();
+        }
 
         if (is_array($options['source_field'])) {
             list($sourceField, $sourcePropertyPath) = $options['source_field'];


### PR DESCRIPTION
Symfony provides the possibility setting a default value for a choice type form field. The formatter type always overwrites the user setting with the default formatter of the formatter pool. This forbids for example to persist the format together with settings of Sonata blocks and to re-edit them later in the same format, as the form field will just jump back to 'text' format.

Instead, the given value should only be overwritten if no valid format was given by the user.