### PR TITLE
Fix overwriting formatter selection

### DIFF
--- a/Form/Type/FormatterType.php
+++ b/Form/Type/FormatterType.php
@@ -67,7 +67,10 @@ class FormatterType extends AbstractType
             $options['format_field_options']['property_path'] = $formatField;
         }
 
-        $options['format_field_options']['data'] = $this->pool->getDefaultFormatter();
+        if (!array_key_exists('data', $options['format_field_options']) ||
+             !array_key_exists($options['format_field_options']['data'], $this->pool->getFormatters())) {
+            $options['format_field_options']['data'] = $this->pool->getDefaultFormatter();
+        }
 
         if (is_array($options['source_field'])) {
             list($sourceField, $sourcePropertyPath) = $options['source_field'];

--- a/Resources/doc/reference/formatter_widget.rst
+++ b/Resources/doc/reference/formatter_widget.rst
@@ -69,6 +69,10 @@ Now, let's define a form to edit this post:
         ->add('content', 'sonata_formatter_type', array(
             'event_dispatcher' => $formBuilder->getEventDispatcher(),
             'format_field'   => 'contentFormatter',
+            'format_field_options' => array(
+                'choices' => array('text', 'markdown'),
+                'data' => 'markdown',
+            ),
             'source_field'   => 'rawContent',
             'source_field_options'      => array(
                 'attr' => array('class' => 'span10', 'rows' => 20)
@@ -78,6 +82,7 @@ Now, let's define a form to edit this post:
         ))
 
 The form type defines a ``contentFormatter`` with a select choice (``sonata_formatter_type_selector``).
+The available formatter choices are ``text`` and ``markdown`` here, with the ``markdown`` formatter preselected.
 The ``sonata_formatter_type_selector`` takes various options:
 
 * ``listener`` (optional, default is ``true``);


### PR DESCRIPTION
### Changelog

```markdown
### Fixed
- Fix overwriting formatter selection
```

### Subject

Symfony provides the possibility to give a default value for a choice type form field when setting up a form. The formatter type is such choice field.
It is currently however overwritten with the default formatter of the formatter pool without warning.
A common use case is to persist the format together with other settings of e.g. Sonata blocks and to re-edit them later in the same format, but currently the form field will just jump back to 'text' format and render the block content unusable.
Instead, the given value should only be overwritten if no valid format was given by the user.
