### PR TITLE
fix simple widget not updating in sonata page block #125

### DIFF
--- a/Resources/views/Form/ckeditor.html.twig
+++ b/Resources/views/Form/ckeditor.html.twig
@@ -1,0 +1,7 @@
+{% for plugin_name, plugin in ckeditor_plugins %}
+	{{ ckeditor_plugin(plugin_name, plugin) }}
+{% endfor %}
+
+{{ ckeditor_widget(ckeditor_field_id, ckeditor_configuration, {
+	input_sync: true,
+}) }}

--- a/Resources/views/Form/formatter.html.twig
+++ b/Resources/views/Form/formatter.html.twig
@@ -103,7 +103,9 @@
             {% elseif format == 'rawhtml' %}
                 elms.markItUp(markitup_sonataHtmlSettings);
             {% elseif format == 'richhtml' %}
-                {{ ckeditor_widget(form.vars.id, ckeditor_configuration) }};
+                {{ ckeditor_widget(form.vars.id, ckeditor_configuration, {
+                    input_sync: true,
+                }) }}
             {% endif %}
 
             var parent = elms.parents('div.markItUp');

--- a/Resources/views/Form/formatter.html.twig
+++ b/Resources/views/Form/formatter.html.twig
@@ -40,13 +40,7 @@
                         appendClass = 'html';
                         break;
                     case 'richhtml':
-                        {% for plugin_name, plugin in ckeditor_plugins %}
-                            {{ ckeditor_plugin(plugin_name, plugin) }}
-                        {% endfor %}
-
-                        {{ ckeditor_widget(form.children[source_field].vars.id, ckeditor_configuration, {
-                            input_sync: true,
-                        }) }}
+                        {% include 'SonataFormatterBundle:Form:ckeditor.html.twig' with {'ckeditor_field_id': form.children[source_field].vars.id} %}
                 }
 
                 var parent = elms.parents('div.markItUp');
@@ -89,9 +83,7 @@
             {% elseif format == 'rawhtml' %}
                 elms.markItUp(markitup_sonataHtmlSettings);
             {% elseif format == 'richhtml' %}
-                {{ ckeditor_widget(form.vars.id, ckeditor_configuration, {
-                    input_sync: true,
-                }) }}
+                {% include 'SonataFormatterBundle:Form:ckeditor.html.twig' with {'ckeditor_field_id': form.vars.id} %}
             {% endif %}
 
             var parent = elms.parents('div.markItUp');

--- a/Resources/views/Form/formatter.html.twig
+++ b/Resources/views/Form/formatter.html.twig
@@ -9,10 +9,7 @@
     </div>
 
     {{ form_widget(form.children[source_field]) }}
-
     <script>
-        var {{ source_id }}_rich_instance = false;
-
         jQuery(document).ready(function() {
 
             // This code requires CKEDITOR and jQuery MarkItUp
@@ -20,22 +17,11 @@
                 return;
             }
 
-            var isInstanceActive = isInstanceActive || function(instance){
-                return instance && instance.status !== "destroyed";
-            };
-
-            jQuery('#{{ form.children[format_field].vars.id }}').parents("form").on('click', function(event) {
-                if (isInstanceActive({{ source_id }}_rich_instance)) {
-                    {{ source_id }}_rich_instance.updateElement();
-                }
-            });
-
             jQuery('#{{ form.children[format_field].vars.id }}').change(function(event) {
                 var elms = jQuery('#{{ form.children[source_field].vars.id }}');
                 elms.markItUpRemove();
-                if (isInstanceActive({{ source_id }}_rich_instance)) {
-                    {{ source_id }}_rich_instance.destroy();
-                }
+
+                {{ ckeditor_destroy(form.children[source_field].vars.id) }}
 
                 var val = jQuery(this).val();
                 var appendClass = val;
@@ -58,9 +44,9 @@
                             {{ ckeditor_plugin(plugin_name, plugin) }}
                         {% endfor %}
 
-                        {{ source_id }}_rich_instance = {{
-                            ckeditor_widget(form.children[source_field].vars.id, ckeditor_configuration)
-                        }};
+                        {{ ckeditor_widget(form.children[source_field].vars.id, ckeditor_configuration, {
+                            input_sync: true,
+                        }) }}
                 }
 
                 var parent = elms.parents('div.markItUp');


### PR DESCRIPTION
Fixes https://github.com/sonata-project/SonataFormatterBundle/issues/125

## Changelog

```markdown
### Fixed
- Field with `sonata_simple_formatter_type` widget in a block in sonata page's composer doesn't update
```

## Subject

When inserting a `sonata_simple_formatter_type` field in a custom block in sonata page, the content never gets updated when saving.
