### PR TITLE
CKEditor custom plugins loading fix (#196)

### DIFF
--- a/Form/Type/FormatterType.php
+++ b/Form/Type/FormatterType.php
@@ -44,6 +44,7 @@ class FormatterType extends AbstractType
     /**
      * @var PluginManagerInterface
      */
+    protected $pluginManager;
 
     /**
      * Constructor.
@@ -161,7 +162,7 @@ class FormatterType extends AbstractType
             $ckeditorConfiguration = array_merge($ckeditorConfiguration, $contextConfig);
         }
 
-        if($this->pluginManager->hasPlugins()) {
+        if ($this->pluginManager->hasPlugins()) {
             $options['ckeditor_plugins'] = $this->pluginManager->getPlugins();
         }
 

--- a/Form/Type/FormatterType.php
+++ b/Form/Type/FormatterType.php
@@ -162,7 +162,7 @@ class FormatterType extends AbstractType
             $ckeditorConfiguration = array_merge($ckeditorConfiguration, $contextConfig);
         }
 
-        if ($this->pluginManager instanceof PluginManagerInterface && $this->pluginManager->hasPlugins()) {
+        if ($this->pluginManager !== null && $this->pluginManager->hasPlugins()) {
             $options['ckeditor_plugins'] = $this->pluginManager->getPlugins();
         }
 

--- a/Form/Type/FormatterType.php
+++ b/Form/Type/FormatterType.php
@@ -54,7 +54,7 @@ class FormatterType extends AbstractType
      * @param ConfigManagerInterface $configManager An Ivory CKEditor bundle configuration manager
      * @param PluginManagerInterface $pluginManager An Ivory CKEditor bundle plugin manager
      */
-    public function __construct(Pool $pool, TranslatorInterface $translator, ConfigManagerInterface $configManager, PluginManagerInterface $pluginManager)
+    public function __construct(Pool $pool, TranslatorInterface $translator, ConfigManagerInterface $configManager, PluginManagerInterface $pluginManager = null)
     {
         $this->pool = $pool;
         $this->translator = $translator;
@@ -162,7 +162,7 @@ class FormatterType extends AbstractType
             $ckeditorConfiguration = array_merge($ckeditorConfiguration, $contextConfig);
         }
 
-        if ($this->pluginManager->hasPlugins()) {
+        if ($this->pluginManager instanceof PluginManagerInterface && $this->pluginManager->hasPlugins()) {
             $options['ckeditor_plugins'] = $this->pluginManager->getPlugins();
         }
 

--- a/Form/Type/FormatterType.php
+++ b/Form/Type/FormatterType.php
@@ -12,6 +12,7 @@
 namespace Sonata\FormatterBundle\Form\Type;
 
 use Ivory\CKEditorBundle\Model\ConfigManagerInterface;
+use Ivory\CKEditorBundle\Model\PluginManagerInterface;
 use Sonata\FormatterBundle\Form\EventListener\FormatterListener;
 use Sonata\FormatterBundle\Formatter\Pool;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -41,17 +42,23 @@ class FormatterType extends AbstractType
     protected $configManager;
 
     /**
+     * @var PluginManagerInterface
+     */
+
+    /**
      * Constructor.
      *
      * @param Pool                   $pool          A Formatter Pool service
      * @param TranslatorInterface    $translator    A Symfony Translator service
      * @param ConfigManagerInterface $configManager An Ivory CKEditor bundle configuration manager
+     * @param PluginManagerInterface $pluginManager An Ivory CKEditor bundle plugin manager
      */
-    public function __construct(Pool $pool, TranslatorInterface $translator, ConfigManagerInterface $configManager)
+    public function __construct(Pool $pool, TranslatorInterface $translator, ConfigManagerInterface $configManager, PluginManagerInterface $pluginManager)
     {
         $this->pool = $pool;
         $this->translator = $translator;
         $this->configManager = $configManager;
+        $this->pluginManager = $pluginManager;
     }
 
     /**
@@ -154,8 +161,13 @@ class FormatterType extends AbstractType
             $ckeditorConfiguration = array_merge($ckeditorConfiguration, $contextConfig);
         }
 
+        if($this->pluginManager->hasPlugins()) {
+            $options['ckeditor_plugins'] = $this->pluginManager->getPlugins();
+        }
+
         $view->vars['ckeditor_configuration'] = $ckeditorConfiguration;
         $view->vars['ckeditor_basepath'] = $options['ckeditor_basepath'];
+        $view->vars['ckeditor_plugins'] = $options['ckeditor_plugins'];
 
         $view->vars['source_id'] = str_replace($view->vars['name'], $view->vars['source_field'], $view->vars['id']);
     }
@@ -188,6 +200,7 @@ class FormatterType extends AbstractType
             ),
             'ckeditor_basepath' => 'bundles/sonataformatter/vendor/ckeditor',
             'ckeditor_context' => null,
+            'ckeditor_plugins' => array(),
             'format_field_options' => array(
                 'choices' => $formatters,
             ),

--- a/Form/Type/FormatterType.php
+++ b/Form/Type/FormatterType.php
@@ -162,7 +162,7 @@ class FormatterType extends AbstractType
             $ckeditorConfiguration = array_merge($ckeditorConfiguration, $contextConfig);
         }
 
-        if ($this->pluginManager !== null && $this->pluginManager->hasPlugins()) {
+        if (null !== $this->pluginManager && $this->pluginManager->hasPlugins()) {
             $options['ckeditor_plugins'] = $this->pluginManager->getPlugins();
         }
 

--- a/Form/Type/SimpleFormatterType.php
+++ b/Form/Type/SimpleFormatterType.php
@@ -57,7 +57,7 @@ class SimpleFormatterType extends AbstractType
             $ckeditorConfiguration = array_merge($ckeditorConfiguration, $contextConfig);
         }
 
-        if($this->pluginManager->hasPlugins()) {
+        if ($this->pluginManager->hasPlugins()) {
             $options['ckeditor_plugins'] = $this->pluginManager->getPlugins();
         }
 

--- a/Form/Type/SimpleFormatterType.php
+++ b/Form/Type/SimpleFormatterType.php
@@ -57,7 +57,7 @@ class SimpleFormatterType extends AbstractType
             $ckeditorConfiguration = array_merge($ckeditorConfiguration, $contextConfig);
         }
 
-        if ($this->pluginManager instanceof PluginManagerInterface && $this->pluginManager->hasPlugins()) {
+        if ($this->pluginManager !== null && $this->pluginManager->hasPlugins()) {
             $options['ckeditor_plugins'] = $this->pluginManager->getPlugins();
         }
 

--- a/Form/Type/SimpleFormatterType.php
+++ b/Form/Type/SimpleFormatterType.php
@@ -57,7 +57,7 @@ class SimpleFormatterType extends AbstractType
             $ckeditorConfiguration = array_merge($ckeditorConfiguration, $contextConfig);
         }
 
-        if ($this->pluginManager !== null && $this->pluginManager->hasPlugins()) {
+        if (null !== $this->pluginManager && $this->pluginManager->hasPlugins()) {
             $options['ckeditor_plugins'] = $this->pluginManager->getPlugins();
         }
 

--- a/Form/Type/SimpleFormatterType.php
+++ b/Form/Type/SimpleFormatterType.php
@@ -12,6 +12,7 @@
 namespace Sonata\FormatterBundle\Form\Type;
 
 use Ivory\CKEditorBundle\Model\ConfigManagerInterface;
+use Ivory\CKEditorBundle\Model\PluginManagerInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
@@ -26,13 +27,20 @@ class SimpleFormatterType extends AbstractType
     protected $configManager;
 
     /**
+     * @var PluginManagerInterface
+     */
+    protected $pluginManager;
+
+    /**
      * Constructor.
      *
      * @param ConfigManagerInterface $configManager An Ivory CKEditor bundle configuration manager
+     * @param PluginManagerInterface $pluginManager An Ivory CKEditor bundle plugin manager
      */
-    public function __construct(ConfigManagerInterface $configManager)
+    public function __construct(ConfigManagerInterface $configManager, PluginManagerInterface $pluginManager)
     {
         $this->configManager = $configManager;
+        $this->pluginManager = $pluginManager;
     }
 
     /**
@@ -49,8 +57,13 @@ class SimpleFormatterType extends AbstractType
             $ckeditorConfiguration = array_merge($ckeditorConfiguration, $contextConfig);
         }
 
+        if($this->pluginManager->hasPlugins()) {
+            $options['ckeditor_plugins'] = $this->pluginManager->getPlugins();
+        }
+
         $view->vars['ckeditor_configuration'] = $ckeditorConfiguration;
         $view->vars['ckeditor_basepath'] = $options['ckeditor_basepath'];
+        $view->vars['ckeditor_plugins'] = $options['ckeditor_plugins'];
 
         $view->vars['format'] = $options['format'];
     }
@@ -74,6 +87,7 @@ class SimpleFormatterType extends AbstractType
             ),
             'ckeditor_basepath' => 'bundles/sonataformatter/vendor/ckeditor',
             'ckeditor_context' => null,
+            'ckeditor_plugins' => array(),
             'format_options' => array(
                 'attr' => array(
                     'class' => 'span10 col-sm-10 col-md-10',

--- a/Form/Type/SimpleFormatterType.php
+++ b/Form/Type/SimpleFormatterType.php
@@ -37,7 +37,7 @@ class SimpleFormatterType extends AbstractType
      * @param ConfigManagerInterface $configManager An Ivory CKEditor bundle configuration manager
      * @param PluginManagerInterface $pluginManager An Ivory CKEditor bundle plugin manager
      */
-    public function __construct(ConfigManagerInterface $configManager, PluginManagerInterface $pluginManager)
+    public function __construct(ConfigManagerInterface $configManager, PluginManagerInterface $pluginManager = null)
     {
         $this->configManager = $configManager;
         $this->pluginManager = $pluginManager;
@@ -57,7 +57,7 @@ class SimpleFormatterType extends AbstractType
             $ckeditorConfiguration = array_merge($ckeditorConfiguration, $contextConfig);
         }
 
-        if ($this->pluginManager->hasPlugins()) {
+        if ($this->pluginManager instanceof PluginManagerInterface && $this->pluginManager->hasPlugins()) {
             $options['ckeditor_plugins'] = $this->pluginManager->getPlugins();
         }
 

--- a/Resources/config/form.xml
+++ b/Resources/config/form.xml
@@ -6,10 +6,12 @@
             <argument type="service" id="sonata.formatter.pool"/>
             <argument type="service" id="translator"/>
             <argument type="service" id="ivory_ck_editor.config_manager"/>
+            <argument type="service" id="ivory_ck_editor.plugin_manager"/>
         </service>
         <service id="sonata.formatter.form.type.simple" class="Sonata\FormatterBundle\Form\Type\SimpleFormatterType">
             <tag name="form.type" alias="sonata_simple_formatter_type"/>
             <argument type="service" id="ivory_ck_editor.config_manager"/>
+            <argument type="service" id="ivory_ck_editor.plugin_manager"/>
         </service>
     </services>
 </container>

--- a/Resources/views/Form/formatter.html.twig
+++ b/Resources/views/Form/formatter.html.twig
@@ -54,6 +54,10 @@
                         appendClass = 'html';
                         break;
                     case 'richhtml':
+                        {% for plugin_name, plugin in ckeditor_plugins %}
+                            {{ ckeditor_plugin(plugin_name, plugin) }}
+                        {% endfor %}
+
                         {{ source_id }}_rich_instance = {{
                             ckeditor_widget(form.children[source_field].vars.id, ckeditor_configuration)
                         }};

--- a/Tests/Form/Type/FormatterTypeTest.php
+++ b/Tests/Form/Type/FormatterTypeTest.php
@@ -27,8 +27,9 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
 
         $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
         $configManager = $this->getMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
+        $pluginManager = $this->getMock('Ivory\CKEditorBundle\Model\PluginManagerInterface');
 
-        $type = new FormatterType($pool, $translator, $configManager);
+        $type = new FormatterType($pool, $translator, $configManager, $pluginManager);
 
         $choiceFormBuilder = $this->getMock('Symfony\Component\Form\FormBuilderInterface');
         $choiceFormBuilder->expects($this->once())->method('getOption')->with('choices')->will($this->returnValue(array('foo' => 'bar')));
@@ -58,8 +59,9 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
         $pool = $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')->disableOriginalConstructor()->getMock();
         $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
         $configManager = $this->getMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
+        $pluginManager = $this->getMock('Ivory\CKEditorBundle\Model\PluginManagerInterface');
 
-        $type = new FormatterType($pool, $translator, $configManager);
+        $type = new FormatterType($pool, $translator, $configManager, $pluginManager);
 
         $choiceFormBuilder = $this->getMock('Symfony\Component\Form\FormBuilderInterface');
         $choiceFormBuilder->expects($this->once())->method('getOption')->with('choices')->will($this->returnValue(array('foo' => 'bar', 'foo2' => 'bar2')));
@@ -88,13 +90,14 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
         $pool = $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')->getMock();
         $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
         $configManager = $this->getMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
+        $pluginManager = $this->getMock('Ivory\CKEditorBundle\Model\PluginManagerInterface');
 
         $formatters = array('text' => 'Text', 'html' => 'HTML', 'markdown' => 'Markdown');
 
         $selectedFormat = 'html';
 
         $pool->method('getFormatters')->will($this->returnValue($formatters));
-        $type = new FormatterType($pool, $translator, $configManager);
+        $type = new FormatterType($pool, $translator, $configManager, $pluginManager);
 
         $choiceFormBuilder = $this->getMock('Symfony\Component\Form\FormBuilderInterface');
         $choiceFormBuilder->expects($this->once())->method('getOption')->with('choices')->will($this->returnValue($formatters));
@@ -132,13 +135,14 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
         $pool = $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')->getMock();
         $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
         $configManager = $this->getMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
+        $pluginManager = $this->getMock('Ivory\CKEditorBundle\Model\PluginManagerInterface');
 
         $formatters = array('text' => 'Text', 'html' => 'HTML', 'markdown' => 'Markdown');
         $defaultFormatter = 'text';
 
         $pool->method('getFormatters')->will($this->returnValue($formatters));
         $pool->method('getDefaultFormatter')->will($this->returnValue('text'));
-        $type = new FormatterType($pool, $translator, $configManager);
+        $type = new FormatterType($pool, $translator, $configManager, $pluginManager);
 
         $choiceFormBuilder = $this->getMock('Symfony\Component\Form\FormBuilderInterface');
         $choiceFormBuilder->expects($this->once())->method('getOption')->with('choices')->will($this->returnValue($formatters));
@@ -175,6 +179,7 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
         $pool = $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')->disableOriginalConstructor()->getMock();
         $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
         $configManager = $this->getMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
+        $pluginManager = $this->getMock('Ivory\CKEditorBundle\Model\PluginManagerInterface');
 
         $defaultConfig = 'default';
         $defaultConfigValues = array('toolbar' => array('Button1'));
@@ -182,7 +187,7 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
         $configManager->expects($this->once())->method('hasConfig')->with($defaultConfig)->will($this->returnValue(true));
         $configManager->expects($this->once())->method('getConfig')->with($defaultConfig)->will($this->returnValue($defaultConfigValues));
 
-        $type = new FormatterType($pool, $translator, $configManager);
+        $type = new FormatterType($pool, $translator, $configManager, $pluginManager);
 
         /** @var \Symfony\Component\Form\FormView $view */
         $view = $this->getMock('Symfony\Component\Form\FormView');
@@ -195,6 +200,7 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
             'format_field_options' => 'SomeOptions',
             'ckeditor_context' => null,
             'ckeditor_basepath' => '',
+            'ckeditor_plugins' => array(),
             'ckeditor_toolbar_icons' => array(),
         ));
 
@@ -206,12 +212,13 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
         $pool = $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')->disableOriginalConstructor()->getMock();
         $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
         $configManager = $this->getMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
+        $pluginManager = $this->getMock('Ivory\CKEditorBundle\Model\PluginManagerInterface');
 
         $defaultConfig = 'default';
         $configManager->expects($this->once())->method('getDefaultConfig')->will($this->returnValue($defaultConfig));
         $configManager->expects($this->once())->method('hasConfig')->with($defaultConfig)->will($this->returnValue(false));
 
-        $type = new FormatterType($pool, $translator, $configManager);
+        $type = new FormatterType($pool, $translator, $configManager, $pluginManager);
 
         $ckEditorToolBarIcons = array('Icon 1');
 
@@ -226,6 +233,7 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
             'format_field_options' => 'SomeOptions',
             'ckeditor_context' => null,
             'ckeditor_basepath' => '',
+            'ckeditor_plugins' => array(),
             'ckeditor_toolbar_icons' => $ckEditorToolBarIcons,
         ));
 
@@ -238,6 +246,7 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
         $pool = $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')->disableOriginalConstructor()->getMock();
         $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
         $configManager = $this->getMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
+        $pluginManager = $this->getMock('Ivory\CKEditorBundle\Model\PluginManagerInterface');
 
         $defaultConfig = 'default';
         $defaultConfigValues = array('toolbar' => array('Button 1'));
@@ -245,7 +254,7 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
         $configManager->expects($this->once())->method('hasConfig')->with($defaultConfig)->will($this->returnValue(true));
         $configManager->expects($this->once())->method('getConfig')->with($defaultConfig)->will($this->returnValue($defaultConfigValues));
 
-        $type = new FormatterType($pool, $translator, $configManager);
+        $type = new FormatterType($pool, $translator, $configManager, $pluginManager);
 
         $ckEditorToolBarIcons = array('Icon 1');
 
@@ -260,6 +269,7 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
             'format_field_options' => 'SomeOptions',
             'ckeditor_context' => null,
             'ckeditor_basepath' => '',
+            'ckeditor_plugins' => array(),
             'ckeditor_toolbar_icons' => $ckEditorToolBarIcons,
         ));
 
@@ -271,8 +281,9 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
         $pool = $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')->disableOriginalConstructor()->getMock();
         $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
         $configManager = $this->getMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
+        $pluginManager = $this->getMock('Ivory\CKEditorBundle\Model\PluginManagerInterface');
 
-        $type = new FormatterType($pool, $translator, $configManager);
+        $type = new FormatterType($pool, $translator, $configManager, $pluginManager);
 
         $ckEditorToolBarIcons = array('Icon 1');
 
@@ -296,6 +307,7 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
             ),
             'ckeditor_context' => null,
             'ckeditor_basepath' => '',
+            'ckeditor_plugins' => array(),
             'ckeditor_toolbar_icons' => $ckEditorToolBarIcons,
         ));
 

--- a/Tests/Form/Type/FormatterTypeTest.php
+++ b/Tests/Form/Type/FormatterTypeTest.php
@@ -12,6 +12,7 @@
 namespace Sonata\FormatterBundle\Tests\Form\Type;
 
 use Sonata\FormatterBundle\Form\Type\FormatterType;
+use Symfony\Component\Form\FormView;
 
 /**
  * Class FormatterTypeTest.
@@ -365,7 +366,7 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
 
         $type = new FormatterType($pool, $translator, $configManager, $pluginManager);
 
-        /** @var \Symfony\Component\Form\FormView $view */
+        /** @var FormView $view */
         $view = $this->getMock('Symfony\Component\Form\FormView');
         $view->vars['id'] = 'SomeId';
         $view->vars['name'] = 'SomeName';

--- a/Tests/Form/Type/FormatterTypeTest.php
+++ b/Tests/Form/Type/FormatterTypeTest.php
@@ -27,9 +27,8 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
 
         $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
         $configManager = $this->getMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
-        $pluginManager = $this->getMock('Ivory\CKEditorBundle\Model\PluginManagerInterface');
 
-        $type = new FormatterType($pool, $translator, $configManager, $pluginManager);
+        $type = new FormatterType($pool, $translator, $configManager);
 
         $choiceFormBuilder = $this->getMock('Symfony\Component\Form\FormBuilderInterface');
         $choiceFormBuilder->expects($this->once())->method('getOption')->with('choices')->will($this->returnValue(array('foo' => 'bar')));
@@ -59,9 +58,8 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
         $pool = $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')->disableOriginalConstructor()->getMock();
         $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
         $configManager = $this->getMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
-        $pluginManager = $this->getMock('Ivory\CKEditorBundle\Model\PluginManagerInterface');
 
-        $type = new FormatterType($pool, $translator, $configManager, $pluginManager);
+        $type = new FormatterType($pool, $translator, $configManager);
 
         $choiceFormBuilder = $this->getMock('Symfony\Component\Form\FormBuilderInterface');
         $choiceFormBuilder->expects($this->once())->method('getOption')->with('choices')->will($this->returnValue(array('foo' => 'bar', 'foo2' => 'bar2')));
@@ -90,14 +88,13 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
         $pool = $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')->getMock();
         $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
         $configManager = $this->getMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
-        $pluginManager = $this->getMock('Ivory\CKEditorBundle\Model\PluginManagerInterface');
 
         $formatters = array('text' => 'Text', 'html' => 'HTML', 'markdown' => 'Markdown');
 
         $selectedFormat = 'html';
 
         $pool->method('getFormatters')->will($this->returnValue($formatters));
-        $type = new FormatterType($pool, $translator, $configManager, $pluginManager);
+        $type = new FormatterType($pool, $translator, $configManager);
 
         $choiceFormBuilder = $this->getMock('Symfony\Component\Form\FormBuilderInterface');
         $choiceFormBuilder->expects($this->once())->method('getOption')->with('choices')->will($this->returnValue($formatters));
@@ -131,6 +128,49 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
     }
 
     public function testBuildFormWithDefaultFormatter()
+    {
+        $pool = $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')->getMock();
+        $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
+        $configManager = $this->getMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
+
+        $formatters = array('text' => 'Text', 'html' => 'HTML', 'markdown' => 'Markdown');
+        $defaultFormatter = 'text';
+
+        $pool->method('getFormatters')->will($this->returnValue($formatters));
+        $pool->method('getDefaultFormatter')->will($this->returnValue('text'));
+        $type = new FormatterType($pool, $translator, $configManager);
+
+        $choiceFormBuilder = $this->getMock('Symfony\Component\Form\FormBuilderInterface');
+        $choiceFormBuilder->expects($this->once())->method('getOption')->with('choices')->will($this->returnValue($formatters));
+
+        $formBuilder = $this->getMock('Symfony\Component\Form\FormBuilderInterface');
+        $formBuilder->expects($this->at(0))->method('add')->with('SomeFormatField', 'choice', array(
+            'property_path' => 'SomeFormatField',
+            'data' => $defaultFormatter,
+            'choices' => $formatters,
+        ));
+        $formBuilder->expects($this->at(1))->method('get')->will($this->returnValue($choiceFormBuilder));
+        $formBuilder->expects($this->at(2))->method('add')->with('SomeSourceField', 'textarea', array(
+            'property_path' => 'SomeSourceField',
+        ));
+
+        $options = array(
+            'format_field' => 'SomeFormatField',
+            'source_field' => 'SomeSourceField',
+            'format_field_options' => array(
+                'property_path' => '',
+                'choices' => $formatters,
+            ),
+            'source_field_options' => array(
+                'property_path' => '',
+            ),
+            'listener' => false,
+        );
+
+        $type->buildForm($formBuilder, $options);
+    }
+
+    public function testBuildFormWithDefaultFormatterAndPluginManager()
     {
         $pool = $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')->getMock();
         $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
@@ -179,7 +219,6 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
         $pool = $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')->disableOriginalConstructor()->getMock();
         $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
         $configManager = $this->getMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
-        $pluginManager = $this->getMock('Ivory\CKEditorBundle\Model\PluginManagerInterface');
 
         $defaultConfig = 'default';
         $defaultConfigValues = array('toolbar' => array('Button1'));
@@ -187,7 +226,7 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
         $configManager->expects($this->once())->method('hasConfig')->with($defaultConfig)->will($this->returnValue(true));
         $configManager->expects($this->once())->method('getConfig')->with($defaultConfig)->will($this->returnValue($defaultConfigValues));
 
-        $type = new FormatterType($pool, $translator, $configManager, $pluginManager);
+        $type = new FormatterType($pool, $translator, $configManager);
 
         /** @var \Symfony\Component\Form\FormView $view */
         $view = $this->getMock('Symfony\Component\Form\FormView');
@@ -212,13 +251,12 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
         $pool = $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')->disableOriginalConstructor()->getMock();
         $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
         $configManager = $this->getMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
-        $pluginManager = $this->getMock('Ivory\CKEditorBundle\Model\PluginManagerInterface');
 
         $defaultConfig = 'default';
         $configManager->expects($this->once())->method('getDefaultConfig')->will($this->returnValue($defaultConfig));
         $configManager->expects($this->once())->method('hasConfig')->with($defaultConfig)->will($this->returnValue(false));
 
-        $type = new FormatterType($pool, $translator, $configManager, $pluginManager);
+        $type = new FormatterType($pool, $translator, $configManager);
 
         $ckEditorToolBarIcons = array('Icon 1');
 
@@ -246,7 +284,6 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
         $pool = $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')->disableOriginalConstructor()->getMock();
         $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
         $configManager = $this->getMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
-        $pluginManager = $this->getMock('Ivory\CKEditorBundle\Model\PluginManagerInterface');
 
         $defaultConfig = 'default';
         $defaultConfigValues = array('toolbar' => array('Button 1'));
@@ -254,7 +291,7 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
         $configManager->expects($this->once())->method('hasConfig')->with($defaultConfig)->will($this->returnValue(true));
         $configManager->expects($this->once())->method('getConfig')->with($defaultConfig)->will($this->returnValue($defaultConfigValues));
 
-        $type = new FormatterType($pool, $translator, $configManager, $pluginManager);
+        $type = new FormatterType($pool, $translator, $configManager);
 
         $ckEditorToolBarIcons = array('Icon 1');
 
@@ -281,9 +318,8 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
         $pool = $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')->disableOriginalConstructor()->getMock();
         $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
         $configManager = $this->getMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
-        $pluginManager = $this->getMock('Ivory\CKEditorBundle\Model\PluginManagerInterface');
 
-        $type = new FormatterType($pool, $translator, $configManager, $pluginManager);
+        $type = new FormatterType($pool, $translator, $configManager);
 
         $ckEditorToolBarIcons = array('Icon 1');
 
@@ -312,5 +348,38 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
         ));
 
         $this->assertSame($view->vars['format_field_options']['data'], $format);
+    }
+
+    public function testBuildViewWithDefaultConfigAndPluginManager()
+    {
+        $pool = $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')->disableOriginalConstructor()->getMock();
+        $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
+        $configManager = $this->getMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
+        $pluginManager = $this->getMock('Ivory\CKEditorBundle\Model\PluginManagerInterface');
+
+        $defaultConfig = 'default';
+        $defaultConfigValues = array('toolbar' => array('Button1'));
+        $configManager->expects($this->once())->method('getDefaultConfig')->will($this->returnValue($defaultConfig));
+        $configManager->expects($this->once())->method('hasConfig')->with($defaultConfig)->will($this->returnValue(true));
+        $configManager->expects($this->once())->method('getConfig')->with($defaultConfig)->will($this->returnValue($defaultConfigValues));
+
+        $type = new FormatterType($pool, $translator, $configManager, $pluginManager);
+
+        /** @var \Symfony\Component\Form\FormView $view */
+        $view = $this->getMock('Symfony\Component\Form\FormView');
+        $view->vars['id'] = 'SomeId';
+        $view->vars['name'] = 'SomeName';
+        $form = $this->getMock('Symfony\Component\Form\FormInterface');
+        $type->buildView($view, $form, array(
+            'source_field' => 'SomeField',
+            'format_field' => 'SomeFormat',
+            'format_field_options' => 'SomeOptions',
+            'ckeditor_context' => null,
+            'ckeditor_basepath' => '',
+            'ckeditor_plugins' => array(),
+            'ckeditor_toolbar_icons' => array(),
+        ));
+
+        $this->assertSame($view->vars['ckeditor_configuration'], $defaultConfigValues);
     }
 }


### PR DESCRIPTION
I am targetting this branch, because it fixes a bug that prevents loading CKEditor plugins from different sources.

Closes #196 
Fixes #196 

## Changelog

```markdown
### Added
- Added support for `PluginManagerInterface` in `FormatterType` and `SimpleFormatterType`
```

## Subject

Fixes CKEditor plugins loading in the RichHTML widget.
