### PR TITLE
Fixed wrong imports in tests

### DIFF
--- a/Tests/Block/FormatterBlockServiceTest.php
+++ b/Tests/Block/FormatterBlockServiceTest.php
@@ -13,10 +13,10 @@ namespace Sonata\FormatterBundle\Tests\Block;
 
 use Sonata\BlockBundle\Block\BlockContext;
 use Sonata\BlockBundle\Model\Block;
-use Sonata\BlockBundle\Tests\Block\AbstractBlockServiceTest;
+use Sonata\BlockBundle\Test\AbstractBlockServiceTestCase;
 use Sonata\FormatterBundle\Block\FormatterBlockService;
 
-final class FormatterBlockServiceTest extends AbstractBlockServiceTest
+final class FormatterBlockServiceTest extends AbstractBlockServiceTestCase
 {
     public function testExecute()
     {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "twig/twig": "^1.12",
         "knplabs/knp-markdown-bundle": "^1.4",
         "egeloen/ckeditor-bundle": "^4.0",
-        "sonata-project/block-bundle": "^3.0",
+        "sonata-project/block-bundle": "^3.1.1",
         "sonata-project/core-bundle": "^3.0"
     },
     "require-dev": {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a fix for the unit tests in the stable branch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- unit tests use the correct namespace in imports.
```

## Subject

This fixes the imports in the test cases. The sub namespace `Tests` isn't public anymore.

