### PR TITLE
Fixed duplicate translation

### DIFF
--- a/Form/Type/FormatterType.php
+++ b/Form/Type/FormatterType.php
@@ -204,6 +204,7 @@ class FormatterType extends AbstractType
             'ckeditor_plugins' => array(),
             'format_field_options' => array(
                 'choices' => $formatters,
+                'choice_translation_domain' => false,
             ),
             'source_field' => null,
             'source_field_options' => array(


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataFormatterBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a patch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed duplicate translation on the format selector
```

## Subject

The options in a choice list were translated two times, once in the php classes and a second time in the twig template. 
