### PR TITLE
Remove deprecation warning for Admin class

### DIFF
--- a/Admin/CkeditorAdminExtension.php
+++ b/Admin/CkeditorAdminExtension.php
@@ -11,7 +11,7 @@
 
 namespace Sonata\FormatterBundle\Admin;
 
-use Sonata\AdminBundle\Admin\AdminExtension;
+use Sonata\AdminBundle\Admin\AbstractAdminExtension;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Route\RouteCollection;
 
@@ -20,7 +20,7 @@ use Sonata\AdminBundle\Route\RouteCollection;
  *
  * @author Kévin Dunglas <kevin@les-tilleuls.coop>
  */
-class CkeditorAdminExtension extends AdminExtension
+class CkeditorAdminExtension extends AbstractAdminExtension
 {
     /**
      * {@inheritdoc}

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "require-dev": {
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
-        "sonata-project/admin-bundle": "^3.0",
+        "sonata-project/admin-bundle": "^3.1",
         "sonata-project/media-bundle": "^3.0",
         "symfony/phpunit-bridge": "^2.7 || ^3.0",
         "symfony/validator": "^2.3 || ^3.0"


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataFormatterBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a BC patch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
 - Removed deprecation warning for `AdminExtension` usage.
```

## Subject

Uses the new `AbstractAdminExtension` class.

