### PR TITLE
Updated install.rst to be valid for Symfony3

### DIFF
--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -42,9 +42,15 @@ Edit the ``config.yml`` file and add these lines:
         strict_variables: "%kernel.debug%"
 
         #sonata
-        form:
-            resources:
-                - 'SonataFormatterBundle:Form:formatter.html.twig'
+        
+        #Uncomment the following 3 liness for Symfony2
+        #form:
+        #    resources:
+        #        - 'SonataFormatterBundle:Form:formatter.html.twig'
+        
+        #Remove the following 2 lines for Symfony2
+        form_themes:
+            - 'SonataFormatterBundle:Form:formatter.html.twig'
 
     sonata_formatter:
         formatters:


### PR DESCRIPTION
I am targetting this branch, because the documentation should be valid for the current version of Symfony
## Changelog

``` markdown

### Changed
- The `config.yml` `twig` section to be up to date with Symfony3

```
## Subject

Changed the `form` twig section to be valid for Symfony3
