### PR TITLE
Check symfony version when using choice_translation_domain

### DIFF
--- a/Form/Type/FormatterType.php
+++ b/Form/Type/FormatterType.php
@@ -197,6 +197,15 @@ class FormatterType extends AbstractType
             $formatters[$code] = $translator->trans($code, array(), 'SonataFormatterBundle');
         }
 
+        $formatFieldOptions = array(
+            'choices' => $formatters,
+        );
+
+        // NEXT_MAJOR: Remove the method_exists hack when dropping support for symfony < 2.7
+        if (count($formatters) > 1 && method_exists('Symfony\Component\Form\AbstractType', 'configureOptions')) {
+            $formatFieldOptions['choice_translation_domain'] = false;
+        }
+
         $resolver->setDefaults(array(
             'inherit_data' => true,
             'event_dispatcher' => null,
@@ -213,10 +222,7 @@ class FormatterType extends AbstractType
             'ckeditor_basepath' => 'bundles/sonataformatter/vendor/ckeditor',
             'ckeditor_context' => null,
             'ckeditor_plugins' => array(),
-            'format_field_options' => array(
-                'choices' => $formatters,
-                'choice_translation_domain' => false,
-            ),
+            'format_field_options' => $formatFieldOptions,
             'source_field' => null,
             'source_field_options' => array(
                 'attr' => array('class' => 'span10 col-sm-10 col-md-10', 'rows' => 20),


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataFormatterBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a patch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Fixes #210

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
 - Fixed usage of `choice_translation_domain` in `FormatterType`
```

## Subject

Checks symfony version when using this option.
