### PR TITLE
Fix SimpleFormatterType for SF3 compatibility

### DIFF
--- a/Form/Type/SimpleFormatterType.php
+++ b/Form/Type/SimpleFormatterType.php
@@ -116,7 +116,10 @@ class SimpleFormatterType extends AbstractType
      */
     public function getParent()
     {
-        return 'textarea';
+        // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
+        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Symfony\Component\Form\Extension\Core\Type\TextareaType'
+            : 'textarea';
     }
 
     /**


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataFormatterBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I'm targeting 3.x branch because its a patch

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Fixes https://github.com/sonata-project/SonataFormatterBundle/issues/207

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Fixed
SimpleFormatterType is now SF3 compatible

```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [ ] Update the tests
- [X] Update the documentation
- [X] Add an upgrade note


