### PR TITLE
Drop old versions

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -32,7 +32,7 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
-                ->scalarNode('default_formatter')->end() // NEXT_MAJOR: make this required
+                ->scalarNode('default_formatter')->isRequired()->cannotBeEmpty()->end()
                 ->arrayNode('formatters')
                     ->useAttributeAsKey('name')
                     ->prototype('array')

--- a/DependencyInjection/SonataFormatterExtension.php
+++ b/DependencyInjection/SonataFormatterExtension.php
@@ -58,7 +58,7 @@ class SonataFormatterExtension extends Extension
 
         if (!array_key_exists($config['default_formatter'], $config['formatters'])) {
             throw new \InvalidArgumentException(sprintf(
-                'SonataFormatterBundle - Invalid default formatter : %s, available : %s',
+                'SonataFormatterBundle - Invalid default formatter: %s, available: %s',
                 $config['default_formatter'],
                 json_encode(array_keys($config['formatters']))
             ));

--- a/DependencyInjection/SonataFormatterExtension.php
+++ b/DependencyInjection/SonataFormatterExtension.php
@@ -56,19 +56,12 @@ class SonataFormatterExtension extends Extension
             $loader->load('ckeditor.xml');
         }
 
-        // NEXT_MAJOR: remove this if block
-        if (!isset($config['default_formatter'])) {
-            @trigger_error(
-                'Not setting the default_formatter configuration node is deprecated since 3.x,'.
-                ' and will no longer be supported in 4.0.',
-                E_USER_DEPRECATED
-            );
-            reset($config['formatters']);
-            $config['default_formatter'] = key($config['formatters']);
-        }
-
         if (!array_key_exists($config['default_formatter'], $config['formatters'])) {
-            throw new \InvalidArgumentException(sprintf('SonataFormatterBundle - Invalid default formatter : %s, available : %s', $config['default_formatter'], json_encode(array_keys($config['formatters']))));
+            throw new \InvalidArgumentException(sprintf(
+                'SonataFormatterBundle - Invalid default formatter : %s, available : %s',
+                $config['default_formatter'],
+                json_encode(array_keys($config['formatters']))
+            ));
         }
 
         $pool = $container->getDefinition('sonata.formatter.pool');
@@ -78,7 +71,12 @@ class SonataFormatterExtension extends Extension
             if (count($configuration['extensions']) == 0) {
                 $env = null;
             } else {
-                $env = new Reference($this->createEnvironment($container, $code, $container->getDefinition($configuration['service']), $configuration['extensions']));
+                $env = new Reference($this->createEnvironment(
+                    $container,
+                    $code,
+                    $container->getDefinition($configuration['service']),
+                    $configuration['extensions']
+                ));
             }
 
             $pool->addMethodCall('add', array($code, new Reference($configuration['service']), $env));

--- a/Form/Type/FormatterType.php
+++ b/Form/Type/FormatterType.php
@@ -22,7 +22,6 @@ use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
 class FormatterType extends AbstractType
@@ -175,16 +174,6 @@ class FormatterType extends AbstractType
     }
 
     /**
-     * NEXT_MAJOR: Remove this method when dropping support for symfony 2.*.
-     *
-     * {@inheritdoc}
-     */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
-    {
-        $this->configureOptions($resolver);
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function configureOptions(OptionsResolver $resolver)
@@ -201,8 +190,7 @@ class FormatterType extends AbstractType
             'choices' => $formatters,
         );
 
-        // NEXT_MAJOR: Remove the method_exists hack when dropping support for symfony < 2.7
-        if (count($formatters) > 1 && method_exists('Symfony\Component\Form\AbstractType', 'configureOptions')) {
+        if (count($formatters) > 1) {
             $formatFieldOptions['choice_translation_domain'] = false;
         }
 

--- a/Form/Type/SimpleFormatterType.php
+++ b/Form/Type/SimpleFormatterType.php
@@ -17,7 +17,6 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 class SimpleFormatterType extends AbstractType
 {
@@ -102,24 +101,11 @@ class SimpleFormatterType extends AbstractType
     }
 
     /**
-     * For Symfony <= 2.8.
-     *
-     * @param OptionsResolverInterface $resolver
-     */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
-    {
-        $this->configureOptions($resolver);
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function getParent()
     {
-        // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
-        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Symfony\Component\Form\Extension\Core\Type\TextareaType'
-            : 'textarea';
+        return 'Symfony\Component\Form\Extension\Core\Type\TextareaType';
     }
 
     /**

--- a/Formatter/Pool.php
+++ b/Formatter/Pool.php
@@ -12,7 +12,7 @@
 namespace Sonata\FormatterBundle\Formatter;
 
 use Psr\Log\LoggerAwareInterface;
-use Psr\Log\LoggerInterface;
+use Psr\Log\LoggerAwareTrait;
 use Psr\Log\NullLogger;
 use Twig_Environment;
 use Twig_Error_Syntax;
@@ -20,6 +20,8 @@ use Twig_Sandbox_SecurityError;
 
 class Pool implements LoggerAwareInterface
 {
+    use LoggerAwareTrait;
+
     /**
      * @var array
      */
@@ -31,60 +33,12 @@ class Pool implements LoggerAwareInterface
     protected $defaultFormatter;
 
     /**
-     * NEXT_MAJOR: use LoggerAwareTrait.
-     *
-     * @var LoggerInterface
+     * @param string $defaultFormatter
      */
-    protected $logger;
-
-    /**
-     * @param string|null $defaultFormatter
-     */
-    public function __construct($defaultFormatter = null)
+    public function __construct($defaultFormatter)
     {
-        if (func_num_args() == 2) {
-            list($logger, $defaultFormatter) = func_get_args();
-            $this->logger = $logger;
-            $this->defaultFormatter = $defaultFormatter;
-        } elseif (func_num_args() == 1) {
-            if ($defaultFormatter instanceof LoggerInterface) {
-                $this->logger = $defaultFormatter;
-            } else {
-                // NEXT_MAJOR: Only keep this block
-                $this->defaultFormatter = $defaultFormatter;
-            }
-        }
-
-        // NEXT_MAJOR: keep the else block only
-        if ($this->logger) {
-            @trigger_error(sprintf(
-                'Providing a logger to %s through the constructor is deprecated since 3.x'.
-                ' and will no longer be possible in 4.0'.
-                ' This argument should be provided through the setLogger() method.',
-                __CLASS__
-            ), E_USER_DEPRECATED);
-        } else {
-            $this->logger = new NullLogger();
-        }
-
-        // NEXT_MAJOR: make defaultFormatter required
-        if (is_null($this->defaultFormatter)) {
-            @trigger_error(sprintf(
-                'Not providing the defaultFormatter argument to %s is deprecated since 3.x.'.
-                ' This argument will become mandatory in 4.0.',
-                __METHOD__
-            ), E_USER_DEPRECATED);
-        }
-    }
-
-    /**
-     * NEXT_MAJOR: use Psr\Log\LoggerAwareTrait.
-     *
-     * @param LoggerInterface will be used to report errors
-     */
-    public function setLogger(LoggerInterface $logger)
-    {
-        $this->logger = $logger;
+        $this->defaultFormatter = $defaultFormatter;
+        $this->logger = new NullLogger();
     }
 
     /**
@@ -175,13 +129,6 @@ class Pool implements LoggerAwareInterface
      */
     public function getDefaultFormatter()
     {
-        // NEXT_MAJOR: This should be removed
-        if (is_null($this->defaultFormatter)) {
-            reset($this->formatters);
-
-            $this->defaultFormatter = key($this->formatters);
-        }
-
         return $this->defaultFormatter;
     }
 }

--- a/Tests/Form/Type/FormatterTypeTest.php
+++ b/Tests/Form/Type/FormatterTypeTest.php
@@ -24,7 +24,7 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
 {
     public function testBuildFormOneChoice()
     {
-        $pool = $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')->disableOriginalConstructor()->getMock();
+        $pool = $this->getPool();
 
         $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
         $configManager = $this->getMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
@@ -56,7 +56,7 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
 
     public function testBuildFormSeveralChoices()
     {
-        $pool = $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')->disableOriginalConstructor()->getMock();
+        $pool = $this->getPool();
         $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
         $configManager = $this->getMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
 
@@ -86,9 +86,7 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
 
     public function testBuildFormWithCustomFormatter()
     {
-        $pool = $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $pool = $this->getPool();
         $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
         $configManager = $this->getMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
 
@@ -132,9 +130,7 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
 
     public function testBuildFormWithDefaultFormatter()
     {
-        $pool = $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $pool = $this->getPool();
         $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
         $configManager = $this->getMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
 
@@ -177,9 +173,7 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
 
     public function testBuildFormWithDefaultFormatterAndPluginManager()
     {
-        $pool = $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $pool = $this->getPool();
         $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
         $configManager = $this->getMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
         $pluginManager = $this->getMock('Ivory\CKEditorBundle\Model\PluginManagerInterface');
@@ -223,7 +217,7 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
 
     public function testBuildViewWithDefaultConfig()
     {
-        $pool = $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')->disableOriginalConstructor()->getMock();
+        $pool = $this->getPool();
         $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
         $configManager = $this->getMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
 
@@ -255,7 +249,7 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
 
     public function testBuildViewWithoutDefaultConfig()
     {
-        $pool = $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')->disableOriginalConstructor()->getMock();
+        $pool = $this->getPool();
         $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
         $configManager = $this->getMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
 
@@ -288,7 +282,7 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
 
     public function testBuildViewWithDefaultConfigAndWithToolbarIcons()
     {
-        $pool = $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')->disableOriginalConstructor()->getMock();
+        $pool = $this->getPool();
         $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
         $configManager = $this->getMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
 
@@ -322,7 +316,7 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
 
     public function testBuildViewWithFormatter()
     {
-        $pool = $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')->disableOriginalConstructor()->getMock();
+        $pool = $this->getPool();
         $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
         $configManager = $this->getMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
 
@@ -359,7 +353,7 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
 
     public function testBuildViewWithDefaultConfigAndPluginManager()
     {
-        $pool = $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')->disableOriginalConstructor()->getMock();
+        $pool = $this->getPool();
         $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
         $configManager = $this->getMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
         $pluginManager = $this->getMock('Ivory\CKEditorBundle\Model\PluginManagerInterface');
@@ -388,5 +382,12 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
         ));
 
         $this->assertSame($view->vars['ckeditor_configuration'], $defaultConfigValues);
+    }
+
+    private function getPool()
+    {
+        return $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')
+            ->disableOriginalConstructor()
+            ->getMock();
     }
 }

--- a/Tests/Formatter/PoolTest.php
+++ b/Tests/Formatter/PoolTest.php
@@ -87,43 +87,6 @@ class PoolTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('default', $pool->getDefaultFormatter());
     }
 
-    /**
-     * NEXT_MAJOR: This should be removed.
-     *
-     * @group legacy
-     */
-    public function testBcDefaultFormatter()
-    {
-        $formatter = new RawFormatter();
-        $env = $this->getMock('\Twig_Environment');
-
-        $pool = new Pool();
-
-        $pool->add('foo', $formatter, $env);
-
-        $this->assertSame('foo', $pool->getDefaultFormatter());
-    }
-
-    /**
-     * NEXT_MAJOR: This should be removed.
-     *
-     * @group legacy
-     */
-    public function testLoggerProvidedThroughConstuctor()
-    {
-        $formatter = new RawFormatter();
-        $pool = new Pool($logger = $this->getMock('Psr\Log\LoggerInterface'));
-        $env = $this->getMock('\Twig_Environment');
-        $env->expects($this->once())->method('render')->will(
-            $this->throwException(new \Twig_Sandbox_SecurityError('Error'))
-        );
-
-        $pool->add('foo', $formatter, $env);
-        $logger->expects($this->once())->method('critical');
-
-        $pool->transform('foo', 'whatever');
-    }
-
     private function getPool()
     {
         $pool = new Pool('whatever');

--- a/Tests/Validator/Constraints/FormatterValidatorTest.php
+++ b/Tests/Validator/Constraints/FormatterValidatorTest.php
@@ -27,9 +27,7 @@ class FormatterValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testValidator()
     {
-        $pool = $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $pool = $this->getPool();
 
         $validator = new FormatterValidator($pool);
         $this->assertInstanceOf('Symfony\Component\Validator\ConstraintValidator', $validator);
@@ -40,7 +38,7 @@ class FormatterValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidCase()
     {
-        $pool = $this->getMock('Sonata\FormatterBundle\Formatter\Pool');
+        $pool = $this->getPool();
         $pool->expects($this->any())
             ->method('has')
             ->will($this->returnValue(false));
@@ -63,9 +61,7 @@ class FormatterValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testValidCase()
     {
-        $pool = $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $pool = $this->getPool();
         $pool->expects($this->any())
             ->method('has')
             ->will($this->returnValue(true));
@@ -83,5 +79,12 @@ class FormatterValidatorTest extends \PHPUnit_Framework_TestCase
         $validator->initialize($this->context);
 
         $validator->validate('existingFormatter', $constraint);
+    }
+
+    private function getPool()
+    {
+        return $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')
+            ->disableOriginalConstructor()
+            ->getMock();
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -22,17 +22,17 @@
         "knplabs/knp-markdown-bundle": "^1.4",
         "sonata-project/block-bundle": "^3.1.1",
         "sonata-project/core-bundle": "^3.0",
-        "symfony/form": "^2.3 || ^3.0",
-        "symfony/framework-bundle": "^2.3 || ^3.0",
-        "symfony/property-access": "^2.3 || ^3.0",
+        "symfony/form": "^2.8 || ^3.0",
+        "symfony/framework-bundle": "^2.8 || ^3.0",
+        "symfony/property-access": "^2.8 || ^3.0",
         "twig/twig": "^1.12"
     },
     "require-dev": {
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
         "sonata-project/admin-bundle": "^3.1",
         "sonata-project/media-bundle": "^3.0",
-        "symfony/phpunit-bridge": "^2.7 || ^3.0",
-        "symfony/validator": "^2.3 || ^3.0"
+        "symfony/phpunit-bridge": "^2.8 || ^3.0",
+        "symfony/validator": "^2.8 || ^3.0"
     },
     "suggest": {
         "sonata-project/admin-bundle": "For using the admin media browser.",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^5.3 || ^7.0",
+        "php": "^5.6 || ^7.0",
         "egeloen/ckeditor-bundle": "^4.0",
         "knplabs/knp-markdown-bundle": "^1.4",
         "sonata-project/block-bundle": "^3.1.1",


### PR DESCRIPTION
I am targetting this branch, because bumping minor version of some deps is considered major.

## Changelog
<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- support for PHP 5.3 through 5.5 was dropped
- support for Symfony 2.3 through 2.7 was dropped
```

## Todo
- [x] merge #222 
- [x] merge 3.x into master
- [x] add upgrade note
- [x] rebase

## Subject

This prepares the next major release
