### PR TITLE
Add missing deprecations

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -32,7 +32,7 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
-                ->scalarNode('default_formatter')->end() // TODO: make it required when the major version is changed
+                ->scalarNode('default_formatter')->end() // NEXT_MAJOR: make this required
                 ->arrayNode('formatters')
                     ->useAttributeAsKey('name')
                     ->prototype('array')

--- a/DependencyInjection/SonataFormatterExtension.php
+++ b/DependencyInjection/SonataFormatterExtension.php
@@ -56,7 +56,7 @@ class SonataFormatterExtension extends Extension
             $loader->load('ckeditor.xml');
         }
 
-        // TODO: To be removed when major version is changed
+        // NEXT_MAJOR: remove this if block
         if (!isset($config['default_formatter'])) {
             reset($config['formatters']);
             $config['default_formatter'] = key($config['formatters']);
@@ -67,7 +67,7 @@ class SonataFormatterExtension extends Extension
         }
 
         $pool = $container->getDefinition('sonata.formatter.pool');
-        // TODO: This should become the first (zero-indexed) argument when the major version is changed
+        // NEXT_MAJOR: This should become the first (zero-indexed) argument
         $pool->addArgument($config['default_formatter']);
 
         foreach ($config['formatters'] as $code => $configuration) {

--- a/DependencyInjection/SonataFormatterExtension.php
+++ b/DependencyInjection/SonataFormatterExtension.php
@@ -72,7 +72,6 @@ class SonataFormatterExtension extends Extension
         }
 
         $pool = $container->getDefinition('sonata.formatter.pool');
-        // NEXT_MAJOR: This should become the first (zero-indexed) argument
         $pool->addArgument($config['default_formatter']);
 
         foreach ($config['formatters'] as $code => $configuration) {

--- a/DependencyInjection/SonataFormatterExtension.php
+++ b/DependencyInjection/SonataFormatterExtension.php
@@ -58,6 +58,11 @@ class SonataFormatterExtension extends Extension
 
         // NEXT_MAJOR: remove this if block
         if (!isset($config['default_formatter'])) {
+            @trigger_error(
+                'Not setting the default_formatter configuration node is deprecated since 3.x,'.
+                ' and will no longer be supported in 4.0.',
+                E_USER_DEPRECATED
+            );
             reset($config['formatters']);
             $config['default_formatter'] = key($config['formatters']);
         }

--- a/Formatter/Pool.php
+++ b/Formatter/Pool.php
@@ -140,11 +140,19 @@ class Pool implements LoggerAwareInterface
                 $text = $env->render($text);
             }
         } catch (Twig_Error_Syntax $e) {
-            $this->logger->critical(sprintf('[FormatterBundle::transform] %s - Error while parsing twig template : %s', $code, $e->getMessage()), array(
+            $this->logger->critical(sprintf(
+                '[FormatterBundle::transform] %s - Error while parsing twig template : %s',
+                $code,
+                $e->getMessage()
+            ), array(
                 'text' => $text,
             ));
         } catch (Twig_Sandbox_SecurityError $e) {
-            $this->logger->critical(sprintf('[FormatterBundle::transform] %s - the user try an non white-listed keyword : %s', $code, $e->getMessage()), array(
+            $this->logger->critical(sprintf(
+                '[FormatterBundle::transform] %s - the user try an non white-listed keyword : %s',
+                $code,
+                $e->getMessage()
+            ), array(
                 'text' => $text,
             ));
         }

--- a/Formatter/Pool.php
+++ b/Formatter/Pool.php
@@ -41,7 +41,7 @@ class Pool
     {
         $this->logger = $logger;
 
-        // TODO: This should become a required first parameter when the major version is changed
+        // NEXT_MAJOR: This should become a required first parameter
         $this->defaultFormatter = $defaultFormatter;
     }
 
@@ -127,7 +127,7 @@ class Pool
      */
     public function getDefaultFormatter()
     {
-        // TODO: This should be removed when the major version is changed
+        // NEXT_MAJOR: This should be removed
         if (is_null($this->defaultFormatter)) {
             reset($this->formatters);
 

--- a/Formatter/Pool.php
+++ b/Formatter/Pool.php
@@ -146,6 +146,7 @@ class Pool implements LoggerAwareInterface
                 $e->getMessage()
             ), array(
                 'text' => $text,
+                'exception' => $e,
             ));
         } catch (Twig_Sandbox_SecurityError $e) {
             $this->logger->critical(sprintf(
@@ -154,6 +155,7 @@ class Pool implements LoggerAwareInterface
                 $e->getMessage()
             ), array(
                 'text' => $text,
+                'exception' => $e,
             ));
         }
 

--- a/Resources/config/formatter.xml
+++ b/Resources/config/formatter.xml
@@ -8,7 +8,9 @@
     </parameters>
     <services>
         <service id="sonata.formatter.pool" class="Sonata\FormatterBundle\Formatter\Pool">
-            <argument type="service" id="logger"/>
+            <call method="setLogger">
+                <argument type="service" id="logger"/>
+            </call>
         </service>
         <service id="sonata.formatter.text.markdown" class="%sonata.formatter.text.markdown.class%">
             <tag name="sonata.text.formatter" code="markdown"/>

--- a/Tests/Form/EventListener/FormatterListenerTest.php
+++ b/Tests/Form/EventListener/FormatterListenerTest.php
@@ -21,7 +21,7 @@ class FormatterListenerTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('RuntimeException');
 
-        $pool = new Pool();
+        $pool = $this->getPool();
 
         $listener = new FormatterListener($pool, '[format]', '[source]', '[target]');
 
@@ -41,7 +41,7 @@ class FormatterListenerTest extends \PHPUnit_Framework_TestCase
             return strtoupper($text);
         }));
 
-        $pool = new Pool();
+        $pool = $this->getPool();
         $pool->add('myformat', $formatter);
 
         $listener = new FormatterListener($pool, '[format]', '[source]', '[target]');
@@ -61,5 +61,13 @@ class FormatterListenerTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertSame($expected, $event->getData());
+    }
+
+    private function getPool()
+    {
+        $pool = new Pool('whatever');
+        $pool->setLogger($this->getMock('Psr\Log\LoggerInterface'));
+
+        return $pool;
     }
 }

--- a/Tests/Form/Type/FormatterTypeTest.php
+++ b/Tests/Form/Type/FormatterTypeTest.php
@@ -86,7 +86,9 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
 
     public function testBuildFormWithCustomFormatter()
     {
-        $pool = $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')->getMock();
+        $pool = $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')
+            ->disableOriginalConstructor()
+            ->getMock();
         $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
         $configManager = $this->getMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
 
@@ -130,7 +132,9 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
 
     public function testBuildFormWithDefaultFormatter()
     {
-        $pool = $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')->getMock();
+        $pool = $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')
+            ->disableOriginalConstructor()
+            ->getMock();
         $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
         $configManager = $this->getMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
 
@@ -173,7 +177,9 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
 
     public function testBuildFormWithDefaultFormatterAndPluginManager()
     {
-        $pool = $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')->getMock();
+        $pool = $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')
+            ->disableOriginalConstructor()
+            ->getMock();
         $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
         $configManager = $this->getMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
         $pluginManager = $this->getMock('Ivory\CKEditorBundle\Model\PluginManagerInterface');

--- a/Tests/Formatter/PoolTest.php
+++ b/Tests/Formatter/PoolTest.php
@@ -86,7 +86,7 @@ class PoolTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('default', $pool->getDefaultFormatter());
     }
 
-    // TODO: This should be removed when the major version is changed
+    // NEXT_MAJOR: This should be removed
     public function testBcDefaultFormatter()
     {
         $formatter = new RawFormatter();

--- a/Tests/Formatter/PoolTest.php
+++ b/Tests/Formatter/PoolTest.php
@@ -22,7 +22,7 @@ class PoolTest extends \PHPUnit_Framework_TestCase
         $env = $this->getMock('\Twig_Environment');
         $env->expects($this->once())->method('render')->will($this->returnValue('Salut'));
 
-        $pool = new Pool();
+        $pool = $this->getPool();
 
         $this->assertFalse($pool->has('foo'));
 
@@ -37,7 +37,7 @@ class PoolTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('RuntimeException');
 
-        $pool = new Pool();
+        $pool = $this->getPool();
         $pool->get('foo');
     }
 
@@ -47,7 +47,7 @@ class PoolTest extends \PHPUnit_Framework_TestCase
         $env = $this->getMock('\Twig_Environment');
         $env->expects($this->once())->method('render')->will($this->throwException(new \Twig_Error_Syntax('Error')));
 
-        $pool = new Pool();
+        $pool = $this->getPool();
         $pool->add('foo', $formatter, $env);
 
         $this->assertSame('Salut', $pool->transform('foo', 'Salut'));
@@ -59,7 +59,7 @@ class PoolTest extends \PHPUnit_Framework_TestCase
         $env = $this->getMock('\Twig_Environment');
         $env->expects($this->once())->method('render')->will($this->throwException(new \Twig_Sandbox_SecurityError('Error')));
 
-        $pool = new Pool();
+        $pool = $this->getPool();
         $pool->add('foo', $formatter, $env);
 
         $this->assertSame('Salut', $pool->transform('foo', 'Salut'));
@@ -73,7 +73,7 @@ class PoolTest extends \PHPUnit_Framework_TestCase
         $env = $this->getMock('\Twig_Environment');
         $env->expects($this->once())->method('render')->will($this->throwException(new \RuntimeException('Error')));
 
-        $pool = new Pool();
+        $pool = $this->getPool();
         $pool->add('foo', $formatter, $env);
 
         $pool->transform('foo', 'Salut');
@@ -81,12 +81,17 @@ class PoolTest extends \PHPUnit_Framework_TestCase
 
     public function testDefaultFormatter()
     {
-        $pool = new Pool(null, 'default');
+        $pool = new Pool('default');
+        $pool->setLogger($this->getMock('Psr\Log\LoggerInterface'));
 
         $this->assertSame('default', $pool->getDefaultFormatter());
     }
 
-    // NEXT_MAJOR: This should be removed
+    /**
+     * NEXT_MAJOR: This should be removed.
+     *
+     * @group legacy
+     */
     public function testBcDefaultFormatter()
     {
         $formatter = new RawFormatter();
@@ -97,5 +102,33 @@ class PoolTest extends \PHPUnit_Framework_TestCase
         $pool->add('foo', $formatter, $env);
 
         $this->assertSame('foo', $pool->getDefaultFormatter());
+    }
+
+    /**
+     * NEXT_MAJOR: This should be removed.
+     *
+     * @group legacy
+     */
+    public function testLoggerProvidedThroughConstuctor()
+    {
+        $formatter = new RawFormatter();
+        $pool = new Pool($logger = $this->getMock('Psr\Log\LoggerInterface'));
+        $env = $this->getMock('\Twig_Environment');
+        $env->expects($this->once())->method('render')->will(
+            $this->throwException(new \Twig_Sandbox_SecurityError('Error'))
+        );
+
+        $pool->add('foo', $formatter, $env);
+        $logger->expects($this->once())->method('critical');
+
+        $pool->transform('foo', 'whatever');
+    }
+
+    private function getPool()
+    {
+        $pool = new Pool('whatever');
+        $pool->setLogger($this->getMock('Psr\Log\LoggerInterface'));
+
+        return $pool;
     }
 }

--- a/Tests/Validator/Constraints/FormatterValidatorTest.php
+++ b/Tests/Validator/Constraints/FormatterValidatorTest.php
@@ -27,7 +27,9 @@ class FormatterValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testValidator()
     {
-        $pool = $this->getMock('Sonata\FormatterBundle\Formatter\Pool');
+        $pool = $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $validator = new FormatterValidator($pool);
         $this->assertInstanceOf('Symfony\Component\Validator\ConstraintValidator', $validator);
@@ -61,7 +63,9 @@ class FormatterValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testValidCase()
     {
-        $pool = $this->getMock('Sonata\FormatterBundle\Formatter\Pool');
+        $pool = $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')
+            ->disableOriginalConstructor()
+            ->getMock();
         $pool->expects($this->any())
             ->method('has')
             ->will($this->returnValue(true));

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -10,6 +10,48 @@ sonata_formatter:
     default_formatter: my_formatter
 ```
 
+## Deprecated injecting a logger through the Sonata\FormatterBundle\Formatter\Pool constructor
+
+Providing a logger to a `Sonata\FormatterBundle\Formatter\Pool` instance should
+now be done through the `setLogger` method.
+
+
+Before:
+
+```php
+use Sonata\FormatterBundle\Formatter\Pool;
+
+new Pool($myLogger, 'myFormatter');
+```
+
+After:
+
+```php
+$pool = new Pool('myFormatter');
+$pool->setLogger($myLogger);
+```
+
+## Deprecated unspecified default formatter in Sonata\FormatterBundle\Formatter\Pool constructor
+
+Instantiating the `Sonata\FormatterBundle\Formatter\Pool` class should be done
+with a `$defaultFormatter` argument.
+
+Before:
+
+```php
+use Sonata\FormatterBundle\Formatter\Pool;
+
+new Pool();
+```
+
+After:
+
+```php
+use Sonata\FormatterBundle\Formatter\Pool;
+
+new Pool('myFormatter');
+```
+
 UPGRADE FROM 3.0 to 3.1
 =======================
 

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,15 @@
 UPGRADE 3.x
 ===========
 
+## Deprecated unspecified default_formatter configuration node
+
+The `default_formatter` configuration node will become required.
+
+```yaml
+sonata_formatter:
+    default_formatter: my_formatter
+```
+
 UPGRADE FROM 3.0 to 3.1
 =======================
 


### PR DESCRIPTION
I am targetting this branch, because this is BC (addind a deprecation notice).

## Changelog

```markdown
### Deprecated
- not specifying the `default_formatter` configuration node is deprecated
- specifying a logger through the `SonataFormatterBundle\Formatter\Pool` constructor is deprecated in favor of specifying it through `setLogger` method
- not specifying a default formatter to the `SonataFormatterBundle\Formatter\Pool` constructor
```

## Subject

See #221 
