### PR TITLE
Add ckeditor templates in sonata_formatter_type and sonata_simple_formatter_type

### DIFF
--- a/Form/Type/FormatterType.php
+++ b/Form/Type/FormatterType.php
@@ -13,6 +13,7 @@ namespace Sonata\FormatterBundle\Form\Type;
 
 use Ivory\CKEditorBundle\Model\ConfigManagerInterface;
 use Ivory\CKEditorBundle\Model\PluginManagerInterface;
+use Ivory\CKEditorBundle\Model\TemplateManagerInterface;
 use Sonata\FormatterBundle\Form\EventListener\FormatterListener;
 use Sonata\FormatterBundle\Formatter\Pool;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -48,19 +49,26 @@ class FormatterType extends AbstractType
     protected $pluginManager;
 
     /**
+     * @var TemplateManagerInterface
+     */
+    protected $templateManager;
+
+    /**
      * Constructor.
      *
-     * @param Pool                   $pool          A Formatter Pool service
-     * @param TranslatorInterface    $translator    A Symfony Translator service
-     * @param ConfigManagerInterface $configManager An Ivory CKEditor bundle configuration manager
-     * @param PluginManagerInterface $pluginManager An Ivory CKEditor bundle plugin manager
+     * @param Pool                     $pool            A Formatter Pool service
+     * @param TranslatorInterface      $translator      A Symfony Translator service
+     * @param ConfigManagerInterface   $configManager   An Ivory CKEditor bundle configuration manager
+     * @param PluginManagerInterface   $pluginManager   An Ivory CKEditor bundle plugin manager
+     * @param TemplateManagerInterface $templateManager An Ivory CKEditor bundle template manager
      */
-    public function __construct(Pool $pool, TranslatorInterface $translator, ConfigManagerInterface $configManager, PluginManagerInterface $pluginManager = null)
+    public function __construct(Pool $pool, TranslatorInterface $translator, ConfigManagerInterface $configManager, PluginManagerInterface $pluginManager = null, TemplateManagerInterface $templateManager = null)
     {
         $this->pool = $pool;
         $this->translator = $translator;
         $this->configManager = $configManager;
         $this->pluginManager = $pluginManager;
+        $this->templateManager = $templateManager;
     }
 
     /**
@@ -167,9 +175,14 @@ class FormatterType extends AbstractType
             $options['ckeditor_plugins'] = $this->pluginManager->getPlugins();
         }
 
+        if (null !== $this->templateManager && $this->templateManager->hasTemplates()) {
+            $options['ckeditor_templates'] = $this->templateManager->getTemplates();
+        }
+
         $view->vars['ckeditor_configuration'] = $ckeditorConfiguration;
         $view->vars['ckeditor_basepath'] = $options['ckeditor_basepath'];
         $view->vars['ckeditor_plugins'] = $options['ckeditor_plugins'];
+        $view->vars['ckeditor_templates'] = $options['ckeditor_templates'];
 
         $view->vars['source_id'] = str_replace($view->vars['name'], $view->vars['source_field'], $view->vars['id']);
     }
@@ -222,6 +235,7 @@ class FormatterType extends AbstractType
             'ckeditor_basepath' => 'bundles/sonataformatter/vendor/ckeditor',
             'ckeditor_context' => null,
             'ckeditor_plugins' => array(),
+            'ckeditor_templates' => array(),
             'format_field_options' => $formatFieldOptions,
             'source_field' => null,
             'source_field_options' => array(

--- a/Form/Type/FormatterType.php
+++ b/Form/Type/FormatterType.php
@@ -51,7 +51,7 @@ class FormatterType extends AbstractType
     /**
      * @var TemplateManagerInterface
      */
-    protected $templateManager;
+    private $templateManager;
 
     /**
      * Constructor.

--- a/Form/Type/SimpleFormatterType.php
+++ b/Form/Type/SimpleFormatterType.php
@@ -35,7 +35,7 @@ class SimpleFormatterType extends AbstractType
     /**
      * @var TemplateManagerInterface
      */
-    protected $templateManager;
+    private $templateManager;
 
     /**
      * Constructor.

--- a/Form/Type/SimpleFormatterType.php
+++ b/Form/Type/SimpleFormatterType.php
@@ -13,6 +13,7 @@ namespace Sonata\FormatterBundle\Form\Type;
 
 use Ivory\CKEditorBundle\Model\ConfigManagerInterface;
 use Ivory\CKEditorBundle\Model\PluginManagerInterface;
+use Ivory\CKEditorBundle\Model\TemplateManagerInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
@@ -32,15 +33,22 @@ class SimpleFormatterType extends AbstractType
     protected $pluginManager;
 
     /**
+     * @var TemplateManagerInterface
+     */
+    protected $templateManager;
+
+    /**
      * Constructor.
      *
-     * @param ConfigManagerInterface $configManager An Ivory CKEditor bundle configuration manager
-     * @param PluginManagerInterface $pluginManager An Ivory CKEditor bundle plugin manager
+     * @param ConfigManagerInterface   $configManager   An Ivory CKEditor bundle configuration manager
+     * @param PluginManagerInterface   $pluginManager   An Ivory CKEditor bundle plugin manager
+     * @param TemplateManagerInterface $templateManager An Ivory CKEditor bundle template manager
      */
-    public function __construct(ConfigManagerInterface $configManager, PluginManagerInterface $pluginManager = null)
+    public function __construct(ConfigManagerInterface $configManager, PluginManagerInterface $pluginManager = null, TemplateManagerInterface $templateManager = null)
     {
         $this->configManager = $configManager;
         $this->pluginManager = $pluginManager;
+        $this->templateManager = $templateManager;
     }
 
     /**
@@ -61,9 +69,14 @@ class SimpleFormatterType extends AbstractType
             $options['ckeditor_plugins'] = $this->pluginManager->getPlugins();
         }
 
+        if (null !== $this->templateManager && $this->templateManager->hasTemplates()) {
+            $options['ckeditor_templates'] = $this->templateManager->getTemplates();
+        }
+
         $view->vars['ckeditor_configuration'] = $ckeditorConfiguration;
         $view->vars['ckeditor_basepath'] = $options['ckeditor_basepath'];
         $view->vars['ckeditor_plugins'] = $options['ckeditor_plugins'];
+        $view->vars['ckeditor_templates'] = $options['ckeditor_templates'];
 
         $view->vars['format'] = $options['format'];
     }
@@ -88,6 +101,7 @@ class SimpleFormatterType extends AbstractType
             'ckeditor_basepath' => 'bundles/sonataformatter/vendor/ckeditor',
             'ckeditor_context' => null,
             'ckeditor_plugins' => array(),
+            'ckeditor_templates' => array(),
             'format_options' => array(
                 'attr' => array(
                     'class' => 'span10 col-sm-10 col-md-10',

--- a/Resources/config/form.xml
+++ b/Resources/config/form.xml
@@ -7,11 +7,13 @@
             <argument type="service" id="translator"/>
             <argument type="service" id="ivory_ck_editor.config_manager"/>
             <argument type="service" id="ivory_ck_editor.plugin_manager"/>
+            <argument type="service" id="ivory_ck_editor.template_manager"/>
         </service>
         <service id="sonata.formatter.form.type.simple" class="Sonata\FormatterBundle\Form\Type\SimpleFormatterType">
             <tag name="form.type" alias="sonata_simple_formatter_type"/>
             <argument type="service" id="ivory_ck_editor.config_manager"/>
             <argument type="service" id="ivory_ck_editor.plugin_manager"/>
+            <argument type="service" id="ivory_ck_editor.template_manager"/>
         </service>
     </services>
 </container>

--- a/Resources/views/Form/ckeditor.html.twig
+++ b/Resources/views/Form/ckeditor.html.twig
@@ -2,6 +2,10 @@
 	{{ ckeditor_plugin(plugin_name, plugin) }}
 {% endfor %}
 
+{% for template_name, template in ckeditor_templates %}
+	{{ ckeditor_template(template_name, template) }}
+{% endfor %}
+
 {{ ckeditor_widget(ckeditor_field_id, ckeditor_configuration, {
 	input_sync: true,
 }) }}

--- a/Tests/Form/Type/FormatterTypeTest.php
+++ b/Tests/Form/Type/FormatterTypeTest.php
@@ -429,4 +429,54 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($view->vars['ckeditor_configuration'], $defaultConfigValues);
     }
+
+    public function testBuildViewWithDefaultConfigAndPluginManagerAndTemplateManagerAndWithTemplates()
+    {
+        $pool = $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')->disableOriginalConstructor()->getMock();
+        $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
+        $configManager = $this->getMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
+        $pluginManager = $this->getMock('Ivory\CKEditorBundle\Model\PluginManagerInterface');
+        $templateManager = $this->getMock('Ivory\CKEditorBundle\Model\TemplateManagerInterface');
+
+        $defaultConfig = 'default';
+        $defaultConfigValues = array('toolbar' => array('Button1'));
+        $configManager->expects($this->once())->method('getDefaultConfig')->will($this->returnValue($defaultConfig));
+        $configManager->expects($this->once())->method('hasConfig')->with($defaultConfig)->will($this->returnValue(true));
+        $configManager->expects($this->once())->method('getConfig')->with($defaultConfig)->will($this->returnValue($defaultConfigValues));
+
+        $templates = array(
+            'imagesPath' => '/bundles/mybundle/templates/images',
+            'templates' => array(
+                array(
+                    'title' => 'My Template',
+                    'image' => 'images.jpg',
+                    'description' => 'My awesome template',
+                    'html' => '<p>Crazy template :)</p>',
+                ),
+            ),
+        );
+
+        $templateManager->expects($this->once())->method('hasTemplates')->will($this->returnValue(true));
+        $templateManager->expects($this->once())->method('getTemplates')->will($this->returnValue($templates));
+
+        $type = new FormatterType($pool, $translator, $configManager, $pluginManager, $templateManager);
+
+        /** @var FormView $view */
+        $view = $this->getMock('Symfony\Component\Form\FormView');
+        $view->vars['id'] = 'SomeId';
+        $view->vars['name'] = 'SomeName';
+        $form = $this->getMock('Symfony\Component\Form\FormInterface');
+        $type->buildView($view, $form, array(
+            'source_field' => 'SomeField',
+            'format_field' => 'SomeFormat',
+            'format_field_options' => 'SomeOptions',
+            'ckeditor_context' => null,
+            'ckeditor_basepath' => '',
+            'ckeditor_plugins' => array(),
+            'ckeditor_templates' => array(),
+            'ckeditor_toolbar_icons' => array(),
+        ));
+
+        $this->assertSame($view->vars['ckeditor_templates'], $templates);
+    }
 }

--- a/Tests/Form/Type/FormatterTypeTest.php
+++ b/Tests/Form/Type/FormatterTypeTest.php
@@ -247,6 +247,7 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
             'ckeditor_context' => null,
             'ckeditor_basepath' => '',
             'ckeditor_plugins' => array(),
+            'ckeditor_templates' => array(),
             'ckeditor_toolbar_icons' => array(),
         ));
 
@@ -279,6 +280,7 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
             'ckeditor_context' => null,
             'ckeditor_basepath' => '',
             'ckeditor_plugins' => array(),
+            'ckeditor_templates' => array(),
             'ckeditor_toolbar_icons' => $ckEditorToolBarIcons,
         ));
 
@@ -314,6 +316,7 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
             'ckeditor_context' => null,
             'ckeditor_basepath' => '',
             'ckeditor_plugins' => array(),
+            'ckeditor_templates' => array(),
             'ckeditor_toolbar_icons' => $ckEditorToolBarIcons,
         ));
 
@@ -351,6 +354,7 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
             'ckeditor_context' => null,
             'ckeditor_basepath' => '',
             'ckeditor_plugins' => array(),
+            'ckeditor_templates' => array(),
             'ckeditor_toolbar_icons' => $ckEditorToolBarIcons,
         ));
 
@@ -384,6 +388,42 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
             'ckeditor_context' => null,
             'ckeditor_basepath' => '',
             'ckeditor_plugins' => array(),
+            'ckeditor_templates' => array(),
+            'ckeditor_toolbar_icons' => array(),
+        ));
+
+        $this->assertSame($view->vars['ckeditor_configuration'], $defaultConfigValues);
+    }
+
+    public function testBuildViewWithDefaultConfigAndPluginManagerAndTemplateManager()
+    {
+        $pool = $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')->disableOriginalConstructor()->getMock();
+        $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
+        $configManager = $this->getMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
+        $pluginManager = $this->getMock('Ivory\CKEditorBundle\Model\PluginManagerInterface');
+        $templateManager = $this->getMock('Ivory\CKEditorBundle\Model\TemplateManagerInterface');
+
+        $defaultConfig = 'default';
+        $defaultConfigValues = array('toolbar' => array('Button1'));
+        $configManager->expects($this->once())->method('getDefaultConfig')->will($this->returnValue($defaultConfig));
+        $configManager->expects($this->once())->method('hasConfig')->with($defaultConfig)->will($this->returnValue(true));
+        $configManager->expects($this->once())->method('getConfig')->with($defaultConfig)->will($this->returnValue($defaultConfigValues));
+
+        $type = new FormatterType($pool, $translator, $configManager, $pluginManager, $templateManager);
+
+        /** @var FormView $view */
+        $view = $this->getMock('Symfony\Component\Form\FormView');
+        $view->vars['id'] = 'SomeId';
+        $view->vars['name'] = 'SomeName';
+        $form = $this->getMock('Symfony\Component\Form\FormInterface');
+        $type->buildView($view, $form, array(
+            'source_field' => 'SomeField',
+            'format_field' => 'SomeFormat',
+            'format_field_options' => 'SomeOptions',
+            'ckeditor_context' => null,
+            'ckeditor_basepath' => '',
+            'ckeditor_plugins' => array(),
+            'ckeditor_templates' => array(),
             'ckeditor_toolbar_icons' => array(),
         ));
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataFormatterBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because it's a patch that add possibility without any BC break.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

No issue about CKeditor's template.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added the possibility to use `templates` defined in your `ivory_ckeditor.yml` in the `sonata_formatter_type` and `sonata_simple_formatter_type`
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

## Subject

<!-- Describe your Pull Request content here -->

If you are using `templates` from CKeditor / IvoryCKeditorBundle, they are now automatically included in the template by `sonata_formatter_type` and `sonata_simple_formatter_type`.