### PR TITLE
Fixed rawhtml format in sonata_simple_formatter_type_widget

### DIFF
--- a/Resources/views/Form/formatter.html.twig
+++ b/Resources/views/Form/formatter.html.twig
@@ -90,6 +90,9 @@
 
             if (parent) {
                 parent.addClass('{{ format }}');
+                {% if format == 'rawhtml' %}
+                    parent.addClass('html');
+                {% endif %}
             }
 
         });


### PR DESCRIPTION
I am targetting 3.x, because it's just a small BC template fix.


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Broken markitup header for rawhtml format in sonata_simple_formatter_type_widget
```

## Subject

When using rawhtml format markitup needs a "html" class to be added to the parent in order to show the header icons. This was already set up for sonata_formatter_type_widget, but not for sonata_simple_formatter_type_widget, so I fixed that. It's ugly but it works.
