### PR TITLE
Removed deprecated getMock in unit tests

### DIFF
--- a/Tests/Form/EventListener/FormatterListenerTest.php
+++ b/Tests/Form/EventListener/FormatterListenerTest.php
@@ -13,9 +13,10 @@ namespace Sonata\FormatterBundle\Tests\Form\EventListener;
 
 use Sonata\FormatterBundle\Form\EventListener\FormatterListener;
 use Sonata\FormatterBundle\Formatter\Pool;
+use Sonata\FormatterBundle\Tests\TestCase;
 use Symfony\Component\Form\FormEvent;
 
-class FormatterListenerTest extends \PHPUnit_Framework_TestCase
+class FormatterListenerTest extends TestCase
 {
     public function testWithInvalidFormatter()
     {
@@ -25,7 +26,7 @@ class FormatterListenerTest extends \PHPUnit_Framework_TestCase
 
         $listener = new FormatterListener($pool, '[format]', '[source]', '[target]');
 
-        $event = new FormEvent($this->getMock('Symfony\Component\Form\Test\FormInterface'), array(
+        $event = new FormEvent($this->createMock('Symfony\Component\Form\Test\FormInterface'), array(
             'format' => 'error',
             'source' => 'data',
             'target' => null,
@@ -36,7 +37,7 @@ class FormatterListenerTest extends \PHPUnit_Framework_TestCase
 
     public function testWithValidFormatter()
     {
-        $formatter = $this->getMock('Sonata\FormatterBundle\Formatter\FormatterInterface');
+        $formatter = $this->createMock('Sonata\FormatterBundle\Formatter\FormatterInterface');
         $formatter->expects($this->once())->method('transform')->will($this->returnCallback(function ($text) {
             return strtoupper($text);
         }));
@@ -46,7 +47,7 @@ class FormatterListenerTest extends \PHPUnit_Framework_TestCase
 
         $listener = new FormatterListener($pool, '[format]', '[source]', '[target]');
 
-        $event = new FormEvent($this->getMock('Symfony\Component\Form\Test\FormInterface'), array(
+        $event = new FormEvent($this->createMock('Symfony\Component\Form\Test\FormInterface'), array(
             'format' => 'myformat',
             'source' => 'data',
             'target' => null,
@@ -66,7 +67,7 @@ class FormatterListenerTest extends \PHPUnit_Framework_TestCase
     private function getPool()
     {
         $pool = new Pool('whatever');
-        $pool->setLogger($this->getMock('Psr\Log\LoggerInterface'));
+        $pool->setLogger($this->createMock('Psr\Log\LoggerInterface'));
 
         return $pool;
     }

--- a/Tests/Form/Type/FormatterTypeTest.php
+++ b/Tests/Form/Type/FormatterTypeTest.php
@@ -12,26 +12,27 @@
 namespace Sonata\FormatterBundle\Tests\Form\Type;
 
 use Sonata\FormatterBundle\Form\Type\FormatterType;
+use Sonata\FormatterBundle\Tests\TestCase;
 use Symfony\Component\Form\FormView;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
  */
-class FormatterTypeTest extends \PHPUnit_Framework_TestCase
+class FormatterTypeTest extends TestCase
 {
     public function testBuildFormOneChoice()
     {
         $pool = $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')->disableOriginalConstructor()->getMock();
 
-        $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
-        $configManager = $this->getMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
+        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
+        $configManager = $this->createMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
 
         $type = new FormatterType($pool, $translator, $configManager);
 
-        $choiceFormBuilder = $this->getMock('Symfony\Component\Form\FormBuilderInterface');
+        $choiceFormBuilder = $this->createMock('Symfony\Component\Form\FormBuilderInterface');
         $choiceFormBuilder->expects($this->once())->method('getOption')->with('choices')->will($this->returnValue(array('foo' => 'bar')));
 
-        $formBuilder = $this->getMock('Symfony\Component\Form\FormBuilderInterface');
+        $formBuilder = $this->createMock('Symfony\Component\Form\FormBuilderInterface');
         $formBuilder->expects($this->exactly(3))->method('add');
         $formBuilder->expects($this->once())->method('get')->will($this->returnValue($choiceFormBuilder));
         $formBuilder->expects($this->once())->method('remove');
@@ -54,15 +55,15 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
     public function testBuildFormSeveralChoices()
     {
         $pool = $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')->disableOriginalConstructor()->getMock();
-        $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
-        $configManager = $this->getMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
+        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
+        $configManager = $this->createMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
 
         $type = new FormatterType($pool, $translator, $configManager);
 
-        $choiceFormBuilder = $this->getMock('Symfony\Component\Form\FormBuilderInterface');
+        $choiceFormBuilder = $this->createMock('Symfony\Component\Form\FormBuilderInterface');
         $choiceFormBuilder->expects($this->once())->method('getOption')->with('choices')->will($this->returnValue(array('foo' => 'bar', 'foo2' => 'bar2')));
 
-        $formBuilder = $this->getMock('Symfony\Component\Form\FormBuilderInterface');
+        $formBuilder = $this->createMock('Symfony\Component\Form\FormBuilderInterface');
         $formBuilder->expects($this->exactly(2))->method('add');
         $formBuilder->expects($this->once())->method('get')->will($this->returnValue($choiceFormBuilder));
 
@@ -86,8 +87,8 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
         $pool = $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')
             ->disableOriginalConstructor()
             ->getMock();
-        $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
-        $configManager = $this->getMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
+        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
+        $configManager = $this->createMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
 
         $formatters = array('text' => 'Text', 'html' => 'HTML', 'markdown' => 'Markdown');
 
@@ -96,7 +97,7 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
         $pool->method('getFormatters')->will($this->returnValue($formatters));
         $type = new FormatterType($pool, $translator, $configManager);
 
-        $choiceFormBuilder = $this->getMock('Symfony\Component\Form\FormBuilderInterface');
+        $choiceFormBuilder = $this->createMock('Symfony\Component\Form\FormBuilderInterface');
         $choiceFormBuilder->expects($this->once())->method('getOption')->with('choices')->will($this->returnValue($formatters));
 
         $options = array(
@@ -113,7 +114,7 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
             'listener' => false,
         );
 
-        $formBuilder = $this->getMock('Symfony\Component\Form\FormBuilderInterface');
+        $formBuilder = $this->createMock('Symfony\Component\Form\FormBuilderInterface');
         $formBuilder->expects($this->at(0))->method('add')->with('SomeFormatField', 'choice', array(
             'property_path' => 'SomeFormatField',
             'data' => $selectedFormat,
@@ -132,8 +133,8 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
         $pool = $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')
             ->disableOriginalConstructor()
             ->getMock();
-        $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
-        $configManager = $this->getMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
+        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
+        $configManager = $this->createMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
 
         $formatters = array('text' => 'Text', 'html' => 'HTML', 'markdown' => 'Markdown');
         $defaultFormatter = 'text';
@@ -142,10 +143,10 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
         $pool->method('getDefaultFormatter')->will($this->returnValue('text'));
         $type = new FormatterType($pool, $translator, $configManager);
 
-        $choiceFormBuilder = $this->getMock('Symfony\Component\Form\FormBuilderInterface');
+        $choiceFormBuilder = $this->createMock('Symfony\Component\Form\FormBuilderInterface');
         $choiceFormBuilder->expects($this->once())->method('getOption')->with('choices')->will($this->returnValue($formatters));
 
-        $formBuilder = $this->getMock('Symfony\Component\Form\FormBuilderInterface');
+        $formBuilder = $this->createMock('Symfony\Component\Form\FormBuilderInterface');
         $formBuilder->expects($this->at(0))->method('add')->with('SomeFormatField', 'choice', array(
             'property_path' => 'SomeFormatField',
             'data' => $defaultFormatter,
@@ -177,9 +178,9 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
         $pool = $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')
             ->disableOriginalConstructor()
             ->getMock();
-        $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
-        $configManager = $this->getMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
-        $pluginManager = $this->getMock('Ivory\CKEditorBundle\Model\PluginManagerInterface');
+        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
+        $configManager = $this->createMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
+        $pluginManager = $this->createMock('Ivory\CKEditorBundle\Model\PluginManagerInterface');
 
         $formatters = array('text' => 'Text', 'html' => 'HTML', 'markdown' => 'Markdown');
         $defaultFormatter = 'text';
@@ -188,10 +189,10 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
         $pool->method('getDefaultFormatter')->will($this->returnValue('text'));
         $type = new FormatterType($pool, $translator, $configManager, $pluginManager);
 
-        $choiceFormBuilder = $this->getMock('Symfony\Component\Form\FormBuilderInterface');
+        $choiceFormBuilder = $this->createMock('Symfony\Component\Form\FormBuilderInterface');
         $choiceFormBuilder->expects($this->once())->method('getOption')->with('choices')->will($this->returnValue($formatters));
 
-        $formBuilder = $this->getMock('Symfony\Component\Form\FormBuilderInterface');
+        $formBuilder = $this->createMock('Symfony\Component\Form\FormBuilderInterface');
         $formBuilder->expects($this->at(0))->method('add')->with('SomeFormatField', 'choice', array(
             'property_path' => 'SomeFormatField',
             'data' => $defaultFormatter,
@@ -221,8 +222,8 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
     public function testBuildViewWithDefaultConfig()
     {
         $pool = $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')->disableOriginalConstructor()->getMock();
-        $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
-        $configManager = $this->getMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
+        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
+        $configManager = $this->createMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
 
         $defaultConfig = 'default';
         $defaultConfigValues = array('toolbar' => array('Button1'));
@@ -233,10 +234,10 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
         $type = new FormatterType($pool, $translator, $configManager);
 
         /** @var \Symfony\Component\Form\FormView $view */
-        $view = $this->getMock('Symfony\Component\Form\FormView');
+        $view = $this->createMock('Symfony\Component\Form\FormView');
         $view->vars['id'] = 'SomeId';
         $view->vars['name'] = 'SomeName';
-        $form = $this->getMock('Symfony\Component\Form\FormInterface');
+        $form = $this->createMock('Symfony\Component\Form\FormInterface');
         $type->buildView($view, $form, array(
             'source_field' => 'SomeField',
             'format_field' => 'SomeFormat',
@@ -254,8 +255,8 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
     public function testBuildViewWithoutDefaultConfig()
     {
         $pool = $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')->disableOriginalConstructor()->getMock();
-        $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
-        $configManager = $this->getMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
+        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
+        $configManager = $this->createMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
 
         $defaultConfig = 'default';
         $configManager->expects($this->once())->method('getDefaultConfig')->will($this->returnValue($defaultConfig));
@@ -266,10 +267,10 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
         $ckEditorToolBarIcons = array('Icon 1');
 
         /** @var \Symfony\Component\Form\FormView $view */
-        $view = $this->getMock('Symfony\Component\Form\FormView');
+        $view = $this->createMock('Symfony\Component\Form\FormView');
         $view->vars['id'] = 'SomeId';
         $view->vars['name'] = 'SomeName';
-        $form = $this->getMock('Symfony\Component\Form\FormInterface');
+        $form = $this->createMock('Symfony\Component\Form\FormInterface');
         $type->buildView($view, $form, array(
             'source_field' => 'SomeField',
             'format_field' => 'SomeFormat',
@@ -288,8 +289,8 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
     public function testBuildViewWithDefaultConfigAndWithToolbarIcons()
     {
         $pool = $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')->disableOriginalConstructor()->getMock();
-        $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
-        $configManager = $this->getMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
+        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
+        $configManager = $this->createMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
 
         $defaultConfig = 'default';
         $defaultConfigValues = array('toolbar' => array('Button 1'));
@@ -302,10 +303,10 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
         $ckEditorToolBarIcons = array('Icon 1');
 
         /** @var \Symfony\Component\Form\FormView $view */
-        $view = $this->getMock('Symfony\Component\Form\FormView');
+        $view = $this->createMock('Symfony\Component\Form\FormView');
         $view->vars['id'] = 'SomeId';
         $view->vars['name'] = 'SomeName';
-        $form = $this->getMock('Symfony\Component\Form\FormInterface');
+        $form = $this->createMock('Symfony\Component\Form\FormInterface');
         $type->buildView($view, $form, array(
             'source_field' => 'SomeField',
             'format_field' => 'SomeFormat',
@@ -323,8 +324,8 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
     public function testBuildViewWithFormatter()
     {
         $pool = $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')->disableOriginalConstructor()->getMock();
-        $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
-        $configManager = $this->getMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
+        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
+        $configManager = $this->createMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
 
         $type = new FormatterType($pool, $translator, $configManager);
 
@@ -337,10 +338,10 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
         $format = 'html';
 
         /** @var \Symfony\Component\Form\FormView $view */
-        $view = $this->getMock('Symfony\Component\Form\FormView');
+        $view = $this->createMock('Symfony\Component\Form\FormView');
         $view->vars['id'] = 'SomeId';
         $view->vars['name'] = 'SomeName';
-        $form = $this->getMock('Symfony\Component\Form\FormInterface');
+        $form = $this->createMock('Symfony\Component\Form\FormInterface');
         $type->buildView($view, $form, array(
             'source_field' => 'SomeField',
             'format_field' => 'SomeFormat',
@@ -361,9 +362,9 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
     public function testBuildViewWithDefaultConfigAndPluginManager()
     {
         $pool = $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')->disableOriginalConstructor()->getMock();
-        $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
-        $configManager = $this->getMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
-        $pluginManager = $this->getMock('Ivory\CKEditorBundle\Model\PluginManagerInterface');
+        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
+        $configManager = $this->createMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
+        $pluginManager = $this->createMock('Ivory\CKEditorBundle\Model\PluginManagerInterface');
 
         $defaultConfig = 'default';
         $defaultConfigValues = array('toolbar' => array('Button1'));
@@ -374,10 +375,10 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
         $type = new FormatterType($pool, $translator, $configManager, $pluginManager);
 
         /** @var FormView $view */
-        $view = $this->getMock('Symfony\Component\Form\FormView');
+        $view = $this->createMock('Symfony\Component\Form\FormView');
         $view->vars['id'] = 'SomeId';
         $view->vars['name'] = 'SomeName';
-        $form = $this->getMock('Symfony\Component\Form\FormInterface');
+        $form = $this->createMock('Symfony\Component\Form\FormInterface');
         $type->buildView($view, $form, array(
             'source_field' => 'SomeField',
             'format_field' => 'SomeFormat',
@@ -395,10 +396,10 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
     public function testBuildViewWithDefaultConfigAndPluginManagerAndTemplateManager()
     {
         $pool = $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')->disableOriginalConstructor()->getMock();
-        $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
-        $configManager = $this->getMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
-        $pluginManager = $this->getMock('Ivory\CKEditorBundle\Model\PluginManagerInterface');
-        $templateManager = $this->getMock('Ivory\CKEditorBundle\Model\TemplateManagerInterface');
+        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
+        $configManager = $this->createMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
+        $pluginManager = $this->createMock('Ivory\CKEditorBundle\Model\PluginManagerInterface');
+        $templateManager = $this->createMock('Ivory\CKEditorBundle\Model\TemplateManagerInterface');
 
         $defaultConfig = 'default';
         $defaultConfigValues = array('toolbar' => array('Button1'));
@@ -409,10 +410,10 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
         $type = new FormatterType($pool, $translator, $configManager, $pluginManager, $templateManager);
 
         /** @var FormView $view */
-        $view = $this->getMock('Symfony\Component\Form\FormView');
+        $view = $this->createMock('Symfony\Component\Form\FormView');
         $view->vars['id'] = 'SomeId';
         $view->vars['name'] = 'SomeName';
-        $form = $this->getMock('Symfony\Component\Form\FormInterface');
+        $form = $this->createMock('Symfony\Component\Form\FormInterface');
         $type->buildView($view, $form, array(
             'source_field' => 'SomeField',
             'format_field' => 'SomeFormat',
@@ -430,10 +431,10 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
     public function testBuildViewWithDefaultConfigAndPluginManagerAndTemplateManagerAndWithTemplates()
     {
         $pool = $this->getMockBuilder('Sonata\FormatterBundle\Formatter\Pool')->disableOriginalConstructor()->getMock();
-        $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
-        $configManager = $this->getMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
-        $pluginManager = $this->getMock('Ivory\CKEditorBundle\Model\PluginManagerInterface');
-        $templateManager = $this->getMock('Ivory\CKEditorBundle\Model\TemplateManagerInterface');
+        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
+        $configManager = $this->createMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
+        $pluginManager = $this->createMock('Ivory\CKEditorBundle\Model\PluginManagerInterface');
+        $templateManager = $this->createMock('Ivory\CKEditorBundle\Model\TemplateManagerInterface');
 
         $defaultConfig = 'default';
         $defaultConfigValues = array('toolbar' => array('Button1'));
@@ -459,10 +460,10 @@ class FormatterTypeTest extends \PHPUnit_Framework_TestCase
         $type = new FormatterType($pool, $translator, $configManager, $pluginManager, $templateManager);
 
         /** @var FormView $view */
-        $view = $this->getMock('Symfony\Component\Form\FormView');
+        $view = $this->createMock('Symfony\Component\Form\FormView');
         $view->vars['id'] = 'SomeId';
         $view->vars['name'] = 'SomeName';
-        $form = $this->getMock('Symfony\Component\Form\FormInterface');
+        $form = $this->createMock('Symfony\Component\Form\FormInterface');
         $type->buildView($view, $form, array(
             'source_field' => 'SomeField',
             'format_field' => 'SomeFormat',

--- a/Tests/Formatter/MarkdownFormatterTest.php
+++ b/Tests/Formatter/MarkdownFormatterTest.php
@@ -12,12 +12,13 @@
 namespace Sonata\FormatterBundle\Tests\Formatter;
 
 use Sonata\FormatterBundle\Formatter\MarkdownFormatter;
+use Sonata\FormatterBundle\Tests\TestCase;
 
-class MarkdownFormatterTest extends \PHPUnit_Framework_TestCase
+class MarkdownFormatterTest extends TestCase
 {
     public function testFormatter()
     {
-        $parser = $this->getMock('Knp\Bundle\MarkdownBundle\MarkdownParserInterface');
+        $parser = $this->createMock('Knp\Bundle\MarkdownBundle\MarkdownParserInterface');
         $parser->expects($this->any())->method('transformMarkdown')->will($this->returnValue('<b>Salut</b>'));
         $formatter = new MarkdownFormatter($parser);
 

--- a/Tests/Formatter/PoolTest.php
+++ b/Tests/Formatter/PoolTest.php
@@ -13,8 +13,9 @@ namespace Sonata\FormatterBundle\Tests\Formatter;
 
 use Sonata\FormatterBundle\Formatter\Pool;
 use Sonata\FormatterBundle\Formatter\RawFormatter;
+use Sonata\FormatterBundle\Tests\TestCase;
 
-class PoolTest extends \PHPUnit_Framework_TestCase
+class PoolTest extends TestCase
 {
     public function testPool()
     {
@@ -90,7 +91,7 @@ class PoolTest extends \PHPUnit_Framework_TestCase
     public function testDefaultFormatter()
     {
         $pool = new Pool('default');
-        $pool->setLogger($this->getMock('Psr\Log\LoggerInterface'));
+        $pool->setLogger($this->createMock('Psr\Log\LoggerInterface'));
 
         $this->assertSame('default', $pool->getDefaultFormatter());
     }
@@ -139,7 +140,7 @@ class PoolTest extends \PHPUnit_Framework_TestCase
     private function getPool()
     {
         $pool = new Pool('whatever');
-        $pool->setLogger($this->getMock('Psr\Log\LoggerInterface'));
+        $pool->setLogger($this->createMock('Psr\Log\LoggerInterface'));
 
         return $pool;
     }

--- a/Tests/TestCase.php
+++ b/Tests/TestCase.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\FormatterBundle\Tests;
+
+/**
+ * NEXT_MAJOR: Remove this class when dropping support for < PHPUnit 5.4.
+ *
+ * @internal
+ */
+class TestCase extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @param string $class
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function createMock($class)
+    {
+        if (is_callable('parent::createMock')) {
+            return parent::createMock($class);
+        }
+
+        return $this->getMock($class);
+    }
+}

--- a/Tests/Validator/Constraints/FormatterValidatorTest.php
+++ b/Tests/Validator/Constraints/FormatterValidatorTest.php
@@ -11,9 +11,10 @@
 
 namespace Sonata\FormatterBundle\Tests\Validator\Constraints;
 
+use Sonata\FormatterBundle\Tests\TestCase;
 use Sonata\FormatterBundle\Validator\Constraints\FormatterValidator;
 
-class FormatterValidatorTest extends \PHPUnit_Framework_TestCase
+class FormatterValidatorTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject
@@ -22,7 +23,7 @@ class FormatterValidatorTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->context = $this->getMock(interface_exists('Symfony\Component\Validator\Context\ExecutionContextInterface') ? 'Symfony\Component\Validator\Context\ExecutionContextInterface' : 'Symfony\Component\Validator\ExecutionContextInterface');
+        $this->context = $this->createMock(interface_exists('Symfony\Component\Validator\Context\ExecutionContextInterface') ? 'Symfony\Component\Validator\Context\ExecutionContextInterface' : 'Symfony\Component\Validator\ExecutionContextInterface');
     }
 
     public function testValidator()
@@ -40,13 +41,13 @@ class FormatterValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidCase()
     {
-        $pool = $this->getMock('Sonata\FormatterBundle\Formatter\Pool');
+        $pool = $this->createMock('Sonata\FormatterBundle\Formatter\Pool');
         $pool->expects($this->any())
             ->method('has')
             ->will($this->returnValue(false));
 
         $message = 'Constraint message';
-        $constraint = $this->getMock('Sonata\FormatterBundle\Validator\Constraints\Formatter');
+        $constraint = $this->createMock('Sonata\FormatterBundle\Validator\Constraints\Formatter');
         $constraint->message = $message;
 
         $this->context->expects($this->once())
@@ -71,7 +72,7 @@ class FormatterValidatorTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(true));
 
         $message = 'Constraint message';
-        $constraint = $this->getMock('Sonata\FormatterBundle\Validator\Constraints\Formatter');
+        $constraint = $this->createMock('Sonata\FormatterBundle\Validator\Constraints\Formatter');
         $constraint->message = $message;
 
         $this->context->expects($this->never())


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataBlockBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is for tests only.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->



## Subject

The method `getMock` is deprecated.
