### PR TITLE
Removed TextFormatterExtension implements

### DIFF
--- a/Twig/Extension/TextFormatterExtension.php
+++ b/Twig/Extension/TextFormatterExtension.php
@@ -16,7 +16,7 @@ use Sonata\FormatterBundle\Formatter\Pool;
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class TextFormatterExtension extends \Twig_Extension implements \Twig_Extension_InitRuntimeInterface
+class TextFormatterExtension extends \Twig_Extension
 {
     /**
      * @var Pool


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataFormatterBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a bug fix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Remove wrong implements from TextFormatterExtension
```

## Subject

<!-- Describe your Pull Request content here -->
TextFormatterExtension was implementing an interface `Twig_Extension_InitRuntimeInterface` that is not implementing because it is missing the method.

This method was removed pre 3.0 so this is a bugfix. This is the commit: https://github.com/sonata-project/SonataFormatterBundle/commit/50fdf29b67b386be0fe06b6804bf00097e21fbb3