### PR TITLE
[BUGFIX] Fixing typo in PR #234

### DIFF
--- a/Block/FormatterBlockService.php
+++ b/Block/FormatterBlockService.php
@@ -13,7 +13,7 @@ namespace Sonata\FormatterBundle\Block;
 
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\BlockContextInterface;
-use Sonata\BlockBundle\Block\Service\AbstractBlockService;
+use Sonata\BlockBundle\Block\Service\AbstractAdminBlockService;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\CoreBundle\Model\Metadata;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -23,7 +23,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class FormatterBlockService extends AbstractBlockService
+class FormatterBlockService extends AbstractAdminBlockService
 {
     /**
      * {@inheritdoc}


### PR DESCRIPTION
I am targetting this branch, because it is bugfix reported in PR #234.

## Changelog

- Fixed issue with saving `sonata.formatter.block.formatter` when using within SonataAdminBundle (or Sonata sandbox project)

## Subject

Typo error has been spotted in merged PR #234, this is just fix for that typo error.
