### PR TITLE
Added compatibility with 4.0 of admin bundle and media bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,8 +40,8 @@
         "sonata-project/media-bundle": "For using the admin media browser."
     },
     "conflict": {
-        "sonata-project/admin-bundle": "<3.0 || >= 4.0",
-        "sonata-project/media-bundle": "<3.0 || >= 4.0"
+        "sonata-project/admin-bundle": "<3.0",
+        "sonata-project/media-bundle": "<3.0"
     },
     "autoload": {
         "psr-4": { "Sonata\\FormatterBundle\\": "" },


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataFormatterBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC and allows travis to pass.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes https://github.com/sonata-project/SonataMediaBundle/pull/1225

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added compatibility with 4.0 of admin bundle and media bundle
```
## Subject

<!-- Describe your Pull Request content here -->
We are blocking installs of dev-master of media-bundle and admin-bundle, this makes builds to fail when using those versions. This change is inspired on: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/composer.json#L73.

But actually on that same composer.json there is another dependency blocking 4.0.

How do we handle this? @sonata-project/contributors 