### PR TITLE
Add compatibility with egeloen/ckeditor-bundle 5.0

### DIFF
--- a/Tests/Form/Type/SimpleFormatterTypeTest.php
+++ b/Tests/Form/Type/SimpleFormatterTypeTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\FormatterBundle\Tests\Form\Type;
+
+use Sonata\FormatterBundle\Form\Type\SimpleFormatterType;
+use Sonata\FormatterBundle\Tests\TestCase;
+
+class SimpleFormatterTypeTest extends TestCase
+{
+    public function testBuildForm()
+    {
+        $configManager = $this->createMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
+        $formBuilder = $this->createMock('Symfony\Component\Form\FormBuilderInterface');
+
+        $type = new SimpleFormatterType($configManager);
+
+        $options = array('format' => 'format');
+
+        $type->buildForm($formBuilder, $options);
+    }
+
+    public function testBuildViewWithDefaultConfig()
+    {
+        $configManager = $this->createMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
+        $view = $this->createMock('Symfony\Component\Form\FormView');
+        $form = $this->createMock('Symfony\Component\Form\FormInterface');
+
+        $configManager->expects($this->once())
+            ->method('getConfig')
+            ->with('context')
+            ->will($this->returnValue(array('toolbar' => array('Button1'))));
+        $view->vars['id'] = 'SomeId';
+        $view->vars['name'] = 'SomeName';
+
+        $type = new SimpleFormatterType($configManager);
+
+        $type->buildView($view, $form, array(
+            'format' => 'format',
+            'ckeditor_context' => 'context',
+            'ckeditor_basepath' => '',
+            'ckeditor_plugins' => array(),
+            'ckeditor_templates' => array(),
+            'ckeditor_toolbar_icons' => array(),
+        ));
+
+        $this->assertSame($view->vars['ckeditor_configuration'], array('toolbar' => array('Button1')));
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": "^5.3 || ^7.0",
-        "egeloen/ckeditor-bundle": "^4.0",
+        "egeloen/ckeditor-bundle": "^4.0 || ^5.0",
         "knplabs/knp-markdown-bundle": "^1.4",
         "sonata-project/block-bundle": "^3.2",
         "sonata-project/core-bundle": "^3.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,4 +17,21 @@
         </testsuite>
     </testsuites>
 
+    <filter>
+        <whitelist>
+            <directory>./</directory>
+            <exclude>
+                <directory>./Tests/</directory>
+                <directory>./DataFixtures/</directory>
+                <directory>./Resources/</directory>
+                <directory>./vendor/</directory>
+                <directory>./coverage/</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+
+    <php>
+        <ini name="precision" value="8"/>
+    </php>
+
 </phpunit>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataFormatterBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Add compatibility with `egeloen/ckeditor-bundle 5.0`
```
## Subject

<!-- Describe your Pull Request content here -->
IvoryCkEditorBundle 5.0.0 was released some days ago, this PR enables to install it with SonataFormatterBundle