### PR TITLE
Refactor on browserAction

### DIFF
--- a/Controller/CkeditorAdminController.php
+++ b/Controller/CkeditorAdminController.php
@@ -11,12 +11,13 @@
 
 namespace Sonata\FormatterBundle\Controller;
 
-use Sonata\MediaBundle\Controller\MediaAdminController as BaseMediaAdminController;
+use Sonata\MediaBundle\Controller\MediaAdminController;
+use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
-class CkeditorAdminController extends BaseMediaAdminController
+class CkeditorAdminController extends MediaAdminController
 {
     /**
      * Returns the response object associated with the browser action.
@@ -29,16 +30,21 @@ class CkeditorAdminController extends BaseMediaAdminController
     {
         $this->checkIfMediaBundleIsLoaded();
 
-        if (false === $this->admin->isGranted('LIST')) {
-            throw new AccessDeniedException();
+        // NEXT_MAJOR: Remove this when dropping support for SF < 2.8 (change method signature)
+        if ($this->has('request_stack')) {
+            $request = $this->get('request_stack')->getCurrentRequest();
+        } else {
+            $request = $this->get('request');
         }
+
+        $this->admin->checkAccess('list');
 
         $datagrid = $this->admin->getDatagrid();
 
-        $filters = $this->getRequest()->get('filter');
+        $filters = $request->get('filter');
 
         // set the default context
-        if (!$filters) {
+        if (!$filters || !array_key_exists('context', $filters)) {
             $context = $this->admin->getPersistentParameter('context', $this->get('sonata.media.pool')->getDefaultContext());
         } else {
             $context = $filters['context']['value'];
@@ -47,36 +53,41 @@ class CkeditorAdminController extends BaseMediaAdminController
         $datagrid->setValue('context', null, $context);
         $datagrid->setValue('providerName', null, $this->admin->getPersistentParameter('provider'));
 
-        // retrieve the main category for the tree view
-        $category = null;
-        if ($this->container->has('sonata.media.manager.category')) {
-            $category = $this->container->get('sonata.media.manager.category')->getRootCategory($context);
+        $rootCategory = null;
+        if ($this->has('sonata.media.manager.category')) {
+            $rootCategory = $this->get('sonata.media.manager.category')->getRootCategory($context);
         }
 
-        if (!$filters && null !== $category) {
-            $datagrid->setValue('category', null, $category->getId());
+        if (null !== $rootCategory && !$filters) {
+            $datagrid->setValue('category', null, $rootCategory->getId());
         }
+        if ($this->has('sonata.media.manager.category') && $request->get('category')) {
+            $category = $this->get('sonata.media.manager.category')->findOneBy(array(
+                'id' => (int) $request->get('category'),
+                'context' => $context,
+            ));
 
-        if ($this->getRequest()->get('category')) {
-            $datagrid->setValue('category', null, $this->getRequest()->get('category'));
+            if (!empty($category)) {
+                $datagrid->setValue('category', null, $category->getId());
+            } else {
+                $datagrid->setValue('category', null, $rootCategory->getId());
+            }
         }
 
         $formats = array();
-
         foreach ($datagrid->getResults() as $media) {
             $formats[$media->getId()] = $this->get('sonata.media.pool')->getFormatNamesByContext($media->getContext());
         }
 
         $formView = $datagrid->getForm()->createView();
 
-        // set the theme for the current Admin Form
-        $this->get('twig')->getExtension('form')->renderer->setTheme($formView, $this->admin->getFilterTheme());
+        $this->setFormTheme($formView, $this->admin->getFilterTheme());
 
         return $this->render($this->getTemplate('browser'), array(
             'action' => 'browser',
             'form' => $formView,
             'datagrid' => $datagrid,
-            'root_category' => $category,
+            'root_category' => $rootCategory,
             'formats' => $formats,
         ));
     }
@@ -93,13 +104,17 @@ class CkeditorAdminController extends BaseMediaAdminController
     {
         $this->checkIfMediaBundleIsLoaded();
 
-        if (false === $this->admin->isGranted('CREATE')) {
-            throw new AccessDeniedException();
+        // NEXT_MAJOR: Remove this when dropping support for SF < 2.8 (change method signature)
+        if ($this->has('request_stack')) {
+            $request = $this->get('request_stack')->getCurrentRequest();
+        } else {
+            $request = $this->get('request');
         }
+
+        $this->admin->checkAccess('create');
 
         $mediaManager = $this->get('sonata.media.manager.media');
 
-        $request = $this->getRequest();
         $provider = $request->get('provider');
         $file = $request->files->get('upload');
 
@@ -151,5 +166,25 @@ class CkeditorAdminController extends BaseMediaAdminController
         if (!isset($bundles['SonataMediaBundle'])) {
             throw new \RuntimeException('You cannot use this feature because you have to use SonataMediaBundle');
         }
+    }
+
+    /**
+     * Sets the admin form theme to form view. Used for compatibility between Symfony versions.
+     *
+     * @param FormView $formView
+     * @param string   $theme
+     */
+    private function setFormTheme(FormView $formView, $theme)
+    {
+        $twig = $this->get('twig');
+
+        // BC for Symfony < 3.2 where this runtime does not exists
+        if (!method_exists('Symfony\Bridge\Twig\AppVariable', 'getToken')) {
+            $twig->getExtension('Symfony\Bridge\Twig\Extension\FormExtension')
+                ->renderer->setTheme($formView, $theme);
+
+            return;
+        }
+        $twig->getRuntime('Symfony\Bridge\Twig\Form\TwigRenderer')->setTheme($formView, $theme);
     }
 }

--- a/Tests/Controller/CkeditorAdminControllerTest.php
+++ b/Tests/Controller/CkeditorAdminControllerTest.php
@@ -1,0 +1,179 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\FormatterBundle\Tests\Controller;
+
+use Prophecy\Argument;
+use Sonata\FormatterBundle\Controller\CkeditorAdminController;
+use Sonata\FormatterBundle\Tests\TestCase;
+
+class EntityWithGetId
+{
+    public function getId()
+    {
+    }
+}
+
+class CkeditorAdminControllerTest extends TestCase
+{
+    private $container;
+    private $admin;
+    private $request;
+    private $controller;
+
+    protected function setUp()
+    {
+        $this->container = $this->prophesize('Symfony\Component\DependencyInjection\ContainerInterface');
+        $this->admin = $this->prophesize('Sonata\MediaBundle\Admin\BaseMediaAdmin');
+        $this->request = $this->prophesize('Symfony\Component\HttpFoundation\Request');
+
+        $this->configureCRUDController();
+
+        $this->controller = new CkeditorAdminController();
+        $this->controller->setContainer($this->container->reveal());
+    }
+
+    public function testBrowserAction()
+    {
+        $datagrid = $this->prophesize('Sonata\AdminBundle\Datagrid\DatagridInterface');
+        $pool = $this->prophesize('Sonata\MediaBundle\Provider\Pool');
+        $categoryManager = $this->prophesize('Sonata\MediaBundle\Model\CategoryManagerInterface');
+        $category = $this->prophesize('Sonata\FormatterBundle\Tests\Controller\EntityWithGetId');
+        $form = $this->prophesize('Symfony\Component\Form\Form');
+        $formView = $this->prophesize('Symfony\Component\Form\FormView');
+
+        $this->configureSetFormTheme($formView->reveal(), 'filterTheme');
+        $this->configureRender('templateList', Argument::type('array'), 'renderResponse');
+        $datagrid->setValue('context', null, 'another_context')->shouldBeCalled();
+        $datagrid->setValue('category', null, 1)->shouldBeCalled();
+        $datagrid->setValue('providerName', null, 'provider')->shouldBeCalled();
+        $datagrid->getResults()->willReturn(array());
+        $datagrid->getForm()->willReturn($form->reveal());
+        $pool->getDefaultContext()->willReturn('context');
+        $categoryManager->getRootCategory('another_context')->willReturn($category->reveal());
+        $categoryManager->findOneBy(array(
+            'id' => 2,
+            'context' => 'another_context',
+        ))->willReturn($category->reveal());
+        $category->getId()->willReturn(1);
+        $form->createView()->willReturn($formView->reveal());
+        $this->container->get('sonata.media.pool')->willReturn($pool->reveal());
+        $this->container->has('sonata.media.manager.category')->willReturn(true);
+        $this->container->get('sonata.media.manager.category')->willReturn($categoryManager->reveal());
+        $this->container->getParameter('kernel.bundles')->willReturn(array('SonataMediaBundle' => true));
+        $this->admin->checkAccess('list')->shouldBeCalled();
+        $this->admin->getDatagrid()->willReturn($datagrid->reveal());
+        $this->admin->getPersistentParameter('context', 'context')->willReturn('another_context');
+        $this->admin->getPersistentParameter('provider')->willReturn('provider');
+        $this->admin->getFilterTheme()->willReturn('filterTheme');
+        $this->request->get('filter')->willReturn(array());
+        $this->request->get('category')->willReturn(2);
+
+        $response = $this->controller->browserAction();
+
+        $this->assertSame('renderResponse', $response);
+    }
+
+    public function testUpload()
+    {
+        $media = $this->prophesize('Sonata\MediaBundle\Model\MediaInterface');
+        $mediaManager = $this->prophesize('Sonata\MediaBundle\Model\MediaManagerInterface');
+        $filesBag = $this->prophesize('Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface');
+        $pool = $this->prophesize('Sonata\MediaBundle\Provider\Pool');
+
+        $this->configureRender('templateList', Argument::type('array'), 'renderResponse');
+        $pool->getDefaultContext()->willReturn('context');
+        $filesBag->get('upload')->willReturn(new \stdClass());
+        $mediaManager->create()->willReturn($media->reveal());
+        $mediaManager->save($media->reveal(), 'context', 'provider')->shouldBeCalled();
+        $this->admin->checkAccess('create')->shouldBeCalled();
+        $this->admin->createObjectSecurity($media->reveal())->shouldBeCalled();
+        $this->container->get('sonata.media.manager.media')->willReturn($mediaManager->reveal());
+        $this->container->getParameter('kernel.bundles')->willReturn(array('SonataMediaBundle' => true));
+        $this->container->get('sonata.media.pool')->willReturn($pool->reveal());
+        $this->request->get('provider')->willReturn('provider');
+        $this->request->isMethod('POST')->willReturn(true);
+        $this->request->files = $filesBag->reveal();
+        $this->request->get('context', 'context')->willReturn('context');
+
+        $response = $this->controller->uploadAction();
+
+        $this->assertSame('renderResponse', $response);
+    }
+
+    private function configureCRUDController()
+    {
+        $pool = $this->prophesize('Sonata\AdminBundle\Admin\Pool');
+        $breadcrumbsBuilder = $this->prophesize('Sonata\AdminBundle\Admin\BreadcrumbsBuilderInterface');
+
+        $this->configureGetCurrentRequest($this->request->reveal());
+        $pool->getAdminByAdminCode('admin_code')->willReturn($this->admin->reveal());
+        $this->request->isXmlHttpRequest()->willReturn(false);
+        $this->request->get('_xml_http_request')->willReturn(false);
+        $this->request->get('_sonata_admin')->willReturn('admin_code');
+        $this->request->get('uniqid')->shouldBeCalled();
+        $this->container->get('sonata.admin.pool')->willReturn($pool->reveal());
+        $this->container->get('sonata.admin.breadcrumbs_builder')->willReturn($breadcrumbsBuilder->reveal());
+        $this->admin->getTemplate('layout')->willReturn('layout.html.twig');
+        $this->admin->isChild()->willReturn(false);
+        $this->admin->setRequest($this->request->reveal())->shouldBeCalled();
+    }
+
+    private function configureGetCurrentRequest($request)
+    {
+        // NEXT_MAJOR: Remove this trick when bumping Symfony requirement to 2.8+.
+        if (class_exists('Symfony\Component\HttpFoundation\RequestStack')) {
+            $requestStack = $this->prophesize('Symfony\Component\HttpFoundation\RequestStack');
+
+            $this->container->has('request_stack')->willReturn(true);
+            $this->container->get('request_stack')->willReturn($requestStack->reveal());
+            $requestStack->getCurrentRequest()->willReturn($request);
+        } else {
+            $this->container->has('request_stack')->willReturn(false);
+            $this->container->get('request')->willReturn($request);
+        }
+    }
+
+    private function configureSetFormTheme($formView, $formTheme)
+    {
+        $twig = $this->prophesize('\Twig_Environment');
+        $twigRenderer = $this->prophesize('Symfony\Bridge\Twig\Form\TwigRenderer');
+
+        $this->container->get('twig')->willReturn($twig->reveal());
+
+        // Remove this trick when bumping Symfony requirement to 3.2+.
+        if (method_exists('Symfony\Bridge\Twig\AppVariable', 'getToken')) {
+            $twig->getRuntime('Symfony\Bridge\Twig\Form\TwigRenderer')->willReturn($twigRenderer->reveal());
+        } else {
+            $formExtension = $this->prophesize('Symfony\Bridge\Twig\Extension\FormExtension');
+            $formExtension->renderer = $twigRenderer->reveal();
+
+            // This Throw is for the CRUDController::setFormTheme()
+            $twig->getRuntime('Symfony\Bridge\Twig\Form\TwigRenderer')->willThrow('\Twig_Error_Runtime');
+            $twig->getExtension('Symfony\Bridge\Twig\Extension\FormExtension')->willReturn($formExtension->reveal());
+        }
+        $twigRenderer->setTheme($formView, $formTheme)->shouldBeCalled();
+    }
+
+    private function configureRender($template, $data, $rendered)
+    {
+        $templating = $this->prophesize('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
+        $pool = $this->prophesize('Sonata\MediaBundle\Provider\Pool');
+
+        $this->admin->getPersistentParameters()->willReturn(array('param' => 'param'));
+        $this->container->has('templating')->willReturn(true);
+        $this->container->get('templating')->willReturn($templating->reveal());
+        $this->container->get('sonata.media.pool')->willReturn($pool->reveal());
+        $this->container->getParameter('sonata.formatter.ckeditor.configuration.templates')
+            ->willReturn(array('browser' => $template, 'upload' => $template));
+        $templating->renderResponse($template, $data, null)->willReturn($rendered);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "matthiasnoback/symfony-dependency-injection-test": "^0.1 || ^1.0",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
         "sonata-project/admin-bundle": "^3.1",
-        "sonata-project/media-bundle": "^3.0",
+        "sonata-project/media-bundle": "^3.5",
         "symfony/phpunit-bridge": "^2.7 || ^3.0",
         "symfony/validator": "^2.3 || ^3.0"
     },


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataFormatterBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Use `request_stack`if it is present on `CkEditorAdminController`
- Improve the way we set custom `formTheme` for twig
- Port minor fixes already applied on `SonataMediaBundle` media list
```

## Subject

<!-- Describe your Pull Request content here -->
Improve compatibility with SF3, make code similar to MediaBundle.
