### PR TITLE
Fix sameas usage in media browser file

### DIFF
--- a/Resources/views/Ckeditor/browser.html.twig
+++ b/Resources/views/Ckeditor/browser.html.twig
@@ -232,7 +232,7 @@ file that was distributed with this source code.
                     </a>
 
                 <ul class="dropdown-menu" role="menu">
-                        {% for filter in admin.datagrid.filters if (filter.options['show_filter'] is sameas(true) or filter.options['show_filter'] is null) %}
+                        {% for filter in admin.datagrid.filters if (filter.options['show_filter'] is same as(true) or filter.options['show_filter'] is null) %}
                         <li>
                             <a href="#" class="sonata-toggle-filter sonata-ba-action" filter-target="filter-{{ admin.uniqid }}-{{ filter.name }}" filter-container="filter-container-{{ admin.uniqid() }}">
                                     <i class="fa {{ (filter.isActive() or filter.options['show_filter']) ? 'fa-check-square-o' : 'fa-square-o' }}"></i>{{ admin.trans(filter.label, {}, filter.translationDomain) }}
@@ -258,8 +258,8 @@ file that was distributed with this source code.
                         <div class="row">
                             <div class="col-sm-9">
                                 {% for filter in admin.datagrid.filters %}
-                                    <div class="form-group" id="filter-{{ admin.uniqid }}-{{ filter.name }}" sonata-filter="{{ (filter.options['show_filter'] is sameas(true) or filter.options['show_filter'] is null) ? 'true' : 'false' }}" style="display: {% if (filter.isActive() and filter.options['show_filter'] is null) or (filter.options['show_filter'] is sameas(true)) %}block{% else %}none{% endif %}">
-                                        {% if filter.label is not sameas(false) %}
+                                    <div class="form-group" id="filter-{{ admin.uniqid }}-{{ filter.name }}" sonata-filter="{{ (filter.options['show_filter'] is same as(true) or filter.options['show_filter'] is null) ? 'true' : 'false' }}" style="display: {% if (filter.isActive() and filter.options['show_filter'] is null) or (filter.options['show_filter'] is same as(true)) %}block{% else %}none{% endif %}">
+                                        {% if filter.label is not same as(false) %}
                                             <label for="{{ form.children[filter.formName].children['value'].vars.id }}" class="col-sm-3 control-label">{{ admin.trans(filter.label, {}, filter.translationDomain) }}</label>
                                         {% endif %}
                                         {% set attr = form.children[filter.formName].children['type'].vars.attr|default({}) %}


### PR DESCRIPTION
I am targeting this branch because it's a backward compatible (critical) fix.

## Changelog

```markdown
### Fixed
- Fix the files browser view
```

## Subject
The usage of "sameas" feature of twig always was "same as". **This is a critical issue.**

The `sameas` token generates an error, at least in twig 2. As the following links specify, the current usage is wrong for any version of twig:
- https://twig.sensiolabs.org/doc/1.x/tests/sameas.html
- https://twig.sensiolabs.org/doc/2.x/tests/sameas.html