### PR TITLE
Fixed twig 2 bug when updating rich text

### DIFF
--- a/Formatter/Pool.php
+++ b/Formatter/Pool.php
@@ -137,7 +137,13 @@ class Pool implements LoggerAwareInterface
         try {
             // apply custom extension
             if ($env) {
-                $text = $env->render($text);
+                // NEXT_MAJOR: remove this if block
+                if (class_exists('\Twig_Loader_Array')) {
+                    $template = $env->createTemplate($text);
+                    $text = $template->render(array());
+                } else {
+                    $text = $env->render($text);
+                }
             }
         } catch (Twig_Error_Syntax $e) {
             $this->logger->critical(sprintf(

--- a/Tests/Formatter/PoolTest.php
+++ b/Tests/Formatter/PoolTest.php
@@ -23,7 +23,18 @@ class PoolTest extends TestCase
         $env = $this->getMockBuilder('\Twig_Environment')
             ->disableOriginalConstructor()
             ->getMock();
-        $env->expects($this->once())->method('render')->will($this->returnValue('Salut'));
+
+        // NEXT_MAJOR: remove this if block
+        if (class_exists('\Twig_Loader_Array')) {
+            $template = $this->getMockBuilder('\Twig_Template')
+                ->disableOriginalConstructor()
+                ->getMock();
+            $template->expects($this->once())->method('render')->will($this->returnValue('Salut'));
+
+            $env->expects($this->once())->method('createTemplate')->will($this->returnValue($template));
+        } else {
+            $env->expects($this->once())->method('render')->will($this->returnValue('Salut'));
+        }
 
         $pool = $this->getPool();
 
@@ -50,7 +61,18 @@ class PoolTest extends TestCase
         $env = $this->getMockBuilder('\Twig_Environment')
             ->disableOriginalConstructor()
             ->getMock();
-        $env->expects($this->once())->method('render')->will($this->throwException(new \Twig_Error_Syntax('Error')));
+
+        // NEXT_MAJOR: remove this if block
+        if (class_exists('\Twig_Loader_Array')) {
+            $template = $this->getMockBuilder('\Twig_Template')
+                ->disableOriginalConstructor()
+                ->getMock();
+            $template->expects($this->once())->method('render')->will($this->throwException(new \Twig_Error_Syntax('Error')));
+
+            $env->expects($this->once())->method('createTemplate')->will($this->returnValue($template));
+        } else {
+            $env->expects($this->once())->method('render')->will($this->throwException(new \Twig_Error_Syntax('Error')));
+        }
 
         $pool = $this->getPool();
         $pool->add('foo', $formatter, $env);
@@ -64,7 +86,18 @@ class PoolTest extends TestCase
         $env = $this->getMockBuilder('\Twig_Environment')
             ->disableOriginalConstructor()
             ->getMock();
-        $env->expects($this->once())->method('render')->will($this->throwException(new \Twig_Sandbox_SecurityError('Error')));
+
+        // NEXT_MAJOR: remove this if block
+        if (class_exists('\Twig_Loader_Array')) {
+            $template = $this->getMockBuilder('\Twig_Template')
+                ->disableOriginalConstructor()
+                ->getMock();
+            $template->expects($this->once())->method('render')->will($this->throwException(new \Twig_Sandbox_SecurityError('Error')));
+
+            $env->expects($this->once())->method('createTemplate')->will($this->returnValue($template));
+        } else {
+            $env->expects($this->once())->method('render')->will($this->throwException(new \Twig_Sandbox_SecurityError('Error')));
+        }
 
         $pool = $this->getPool();
         $pool->add('foo', $formatter, $env);
@@ -80,7 +113,18 @@ class PoolTest extends TestCase
         $env = $this->getMockBuilder('\Twig_Environment')
             ->disableOriginalConstructor()
             ->getMock();
-        $env->expects($this->once())->method('render')->will($this->throwException(new \RuntimeException('Error')));
+
+        // NEXT_MAJOR: remove this if block
+        if (class_exists('\Twig_Loader_Array')) {
+            $template = $this->getMockBuilder('\Twig_Template')
+                ->disableOriginalConstructor()
+                ->getMock();
+            $template->expects($this->once())->method('render')->will($this->throwException(new \RuntimeException('Error')));
+
+            $env->expects($this->once())->method('createTemplate')->will($this->returnValue($template));
+        } else {
+            $env->expects($this->once())->method('render')->will($this->throwException(new \RuntimeException('Error')));
+        }
 
         $pool = $this->getPool();
         $pool->add('foo', $formatter, $env);
@@ -127,9 +171,18 @@ class PoolTest extends TestCase
         $env = $this->getMockBuilder('\Twig_Environment')
             ->disableOriginalConstructor()
             ->getMock();
-        $env->expects($this->once())->method('render')->will(
-            $this->throwException(new \Twig_Sandbox_SecurityError('Error'))
-        );
+
+        // NEXT_MAJOR: remove this if block
+        if (class_exists('\Twig_Loader_Array')) {
+            $template = $this->getMockBuilder('\Twig_Template')
+                ->disableOriginalConstructor()
+                ->getMock();
+            $template->expects($this->once())->method('render')->will($this->throwException(new \Twig_Sandbox_SecurityError('Error')));
+
+            $env->expects($this->once())->method('createTemplate')->will($this->returnValue($template));
+        } else {
+            $env->expects($this->once())->method('render')->will($this->throwException(new \Twig_Sandbox_SecurityError('Error')));
+        }
 
         $pool->add('foo', $formatter, $env);
         $logger->expects($this->once())->method('critical');


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataFormatterBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #248

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
 - Fixed twig 2 bug when updating rich text
```

## Subject

This fix will finally support twig 2.
