### PR TITLE
Enable use of custom style sets from ivory_ck_editor

### DIFF
--- a/src/Form/Type/SimpleFormatterType.php
+++ b/src/Form/Type/SimpleFormatterType.php
@@ -13,6 +13,7 @@ namespace Sonata\FormatterBundle\Form\Type;
 
 use Ivory\CKEditorBundle\Model\ConfigManagerInterface;
 use Ivory\CKEditorBundle\Model\PluginManagerInterface;
+use Ivory\CKEditorBundle\Model\StylesSetManagerInterface;
 use Ivory\CKEditorBundle\Model\TemplateManagerInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
@@ -33,23 +34,31 @@ class SimpleFormatterType extends AbstractType
     protected $pluginManager;
 
     /**
+     * @var StylesSetManagerInterface
+     */
+    private $stylesSetManager;
+
+    /**
      * @var TemplateManagerInterface
      */
     private $templateManager;
 
     /**
-     * @param ConfigManagerInterface        $configManager   An Ivory CKEditor bundle configuration manager
-     * @param PluginManagerInterface|null   $pluginManager   An Ivory CKEditor bundle plugin manager
-     * @param TemplateManagerInterface|null $templateManager An Ivory CKEditor bundle template manager
+     * @param ConfigManagerInterface         $configManager    An Ivory CKEditor bundle configuration manager
+     * @param PluginManagerInterface|null    $pluginManager    An Ivory CKEditor bundle plugin manager
+     * @param TemplateManagerInterface|null  $templateManager  An Ivory CKEditor bundle template manager
+     * @param StylesSetManagerInterface|null $stylesSetManager An Ivory CKEditor bundle styles set manager
      */
     public function __construct(
         ConfigManagerInterface $configManager,
         PluginManagerInterface $pluginManager = null,
-        TemplateManagerInterface $templateManager = null
+        TemplateManagerInterface $templateManager = null,
+        StylesSetManagerInterface $stylesSetManager = null
     ) {
         $this->configManager = $configManager;
         $this->pluginManager = $pluginManager;
         $this->templateManager = $templateManager;
+        $this->stylesSetManager = $stylesSetManager;
     }
 
     public function buildView(FormView $view, FormInterface $form, array $options)
@@ -75,10 +84,17 @@ class SimpleFormatterType extends AbstractType
             $options['ckeditor_templates'] = $this->templateManager->getTemplates();
         }
 
+        if (null !== $this->stylesSetManager && $this->stylesSetManager->hasStylesSets()) {
+            $options['ckeditor_style_sets'] = $this->stylesSetManager->getStylesSets();
+        } else {
+            $options['ckeditor_style_sets'] = [];
+        }
+
         $view->vars['ckeditor_configuration'] = $ckeditorConfiguration;
         $view->vars['ckeditor_basepath'] = $options['ckeditor_basepath'];
         $view->vars['ckeditor_plugins'] = $options['ckeditor_plugins'];
         $view->vars['ckeditor_templates'] = $options['ckeditor_templates'];
+        $view->vars['ckeditor_style_sets'] = $options['ckeditor_style_sets'];
 
         $view->vars['format'] = $options['format'];
     }

--- a/src/Resources/config/form.xml
+++ b/src/Resources/config/form.xml
@@ -14,6 +14,7 @@
             <argument type="service" id="ivory_ck_editor.config_manager"/>
             <argument type="service" id="ivory_ck_editor.plugin_manager"/>
             <argument type="service" id="ivory_ck_editor.template_manager"/>
+            <argument type="service" id="ivory_ck_editor.styles_set_manager"/>
         </service>
     </services>
 </container>

--- a/src/Resources/views/Form/ckeditor.html.twig
+++ b/src/Resources/views/Form/ckeditor.html.twig
@@ -6,6 +6,12 @@
 	{{ ckeditor_template(template_name, template) }}
 {% endfor %}
 
+{% if ckeditor_style_sets is defined %}
+    {% for style_set_name, style_set in ckeditor_style_sets %}
+        {{ ckeditor_styles_set(style_set_name, style_set) }}
+    {% endfor %}
+{% endif %}
+
 {{ ckeditor_widget(ckeditor_field_id, ckeditor_configuration, {
 	input_sync: true,
 }) }}

--- a/tests/Form/Type/SimpleFormatterTypeTest.php
+++ b/tests/Form/Type/SimpleFormatterTypeTest.php
@@ -58,4 +58,50 @@ class SimpleFormatterTypeTest extends TestCase
             ['toolbar' => ['Button1'], 'filebrowserImageUploadRouteParameters' => ['format' => 'format']]
         );
     }
+
+    public function testBuildViewWithStylesSet()
+    {
+        $configManager = $this->createMock('Ivory\CKEditorBundle\Model\ConfigManagerInterface');
+        $stylesSetManager = $this->createMock('Ivory\CKEditorBundle\Model\StylesSetManagerInterface');
+        $view = $this->createMock('Symfony\Component\Form\FormView');
+        $form = $this->createMock('Symfony\Component\Form\FormInterface');
+
+        $styleSets = [
+            'my_styleset' => [
+                ['name' => 'Blue Title', 'element' => 'h2', 'styles' => ['color' => 'Blue']],
+                ['name' => 'CSS Style', 'element' => 'span', 'attributes' => ['class' => 'my_style']],
+                ['name' => 'Multiple Element Style', 'element' => ['h2', 'span'], 'attributes' => ['class' => 'my_class']],
+                ['name' => 'Widget Style', 'type' => 'widget', 'widget' => 'my_widget', 'attributes' => ['class' => 'my_widget_style']],
+            ],
+        ];
+
+        $configManager->expects($this->once())
+            ->method('getConfig')
+            ->with('context')
+            ->will($this->returnValue(['toolbar' => ['Button1']]));
+        $stylesSetManager->expects($this->once())
+            ->method('getStylesSets')
+            ->will($this->returnValue($styleSets));
+        $stylesSetManager->expects($this->once())
+            ->method('hasStylesSets')
+            ->will($this->returnValue(true));
+
+        $view->vars['id'] = 'SomeId';
+        $view->vars['name'] = 'SomeName';
+
+        $type = new SimpleFormatterType($configManager, null, null, $stylesSetManager);
+
+        $type->buildView($view, $form, [
+            'format' => 'format',
+            'ckeditor_context' => 'context',
+            'ckeditor_image_format' => 'format',
+            'ckeditor_basepath' => '',
+            'ckeditor_plugins' => [],
+            'ckeditor_templates' => [],
+            'ckeditor_style_sets' => [],
+            'ckeditor_toolbar_icons' => [],
+        ]);
+
+        $this->assertSame($view->vars['ckeditor_style_sets'], $styleSets);
+    }
 }


### PR DESCRIPTION
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataFormatterBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it's a simple feature that does not break BC.

## Changelog

```markdown
### Added
- Added support for stylesSet (ivory_ck_editor configuration)
```

## Subject
Enables the use of custom styles in [ivory_ck_editor](https://github.com/egeloen/IvoryCKEditorBundle/blob/master/Resources/doc/usage/style.rst) when using SimpleFormatterType with the format 'richhtml'.