### PR TITLE
Fixed passing null to transformer

### DIFF
--- a/Formatter/Pool.php
+++ b/Formatter/Pool.php
@@ -139,7 +139,7 @@ class Pool implements LoggerAwareInterface
             if ($env) {
                 // NEXT_MAJOR: remove this if block
                 if (class_exists('\Twig_Loader_Array')) {
-                    $template = $env->createTemplate($text);
+                    $template = $env->createTemplate($text ?: '');
                     $text = $template->render(array());
                 } else {
                     $text = $env->render($text);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataFormatterBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a bugfix.


<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Follow up of #252

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
 - Fixed passing null to transformer
```

## Subject

When using the formatter and allow null values, twig 2 couldn't handle null values and will exit with an exception:

```
Template "__string_template__XXX" is not defined.
```
