### PR TITLE
Drop old versions of php/sf

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,23 +17,23 @@
         }
     ],
     "require": {
-        "php": "^5.3 || ^7.0",
+        "php": "^7.1",
         "egeloen/ckeditor-bundle": "^4.0 || ^5.0",
         "knplabs/knp-markdown-bundle": "^1.4",
         "sonata-project/block-bundle": "^3.2",
         "sonata-project/core-bundle": "^3.0",
-        "symfony/form": "^2.3 || ^3.0",
-        "symfony/framework-bundle": "^2.3 || ^3.0",
-        "symfony/property-access": "^2.3 || ^3.0",
+        "symfony/form": "^2.8 || ^3.2",
+        "symfony/framework-bundle": "^2.8 || ^3.2",
+        "symfony/property-access": "^2.8 || ^3.2",
         "twig/twig": "^1.12 || ^2.0"
     },
     "require-dev": {
-        "matthiasnoback/symfony-dependency-injection-test": "^0.1 || ^1.0",
+        "matthiasnoback/symfony-dependency-injection-test": "^1.1",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
         "sonata-project/admin-bundle": "^3.1",
         "sonata-project/media-bundle": "^3.5",
-        "symfony/phpunit-bridge": "^2.7 || ^3.0",
-        "symfony/validator": "^2.3 || ^3.0"
+        "symfony/phpunit-bridge": "^3.3",
+        "symfony/validator": "^2.8 || ^3.2"
     },
     "suggest": {
         "sonata-project/admin-bundle": "For using the admin media browser.",


### PR DESCRIPTION
I am targeting this branch, because this is BC.

## Changelog

```markdown
### Removed
- Support for old versions of PHP and Symfony.
```
