### PR TITLE
Removed symfony BC layer for old symfony versions

### DIFF
--- a/docs/reference/ckeditor_medias.rst
+++ b/docs/reference/ckeditor_medias.rst
@@ -80,11 +80,11 @@ Here is an example to alter `shortDescription` field of the `ProductAdmin`:
 .. code-block:: php
 
     <?php
-    // BaseProductProvider.php
+    use Sonata\FormatterBundle\Form\Type\FormatterType;
 
     // ...
 
-    $formMapper->add('shortDescription', 'sonata_formatter_type', array(
+    $formMapper->add('shortDescription', FormatterType::class, array(
         'source_field'         => 'rawDescription',
         'source_field_options' => array('attr' => array('class' => 'span10', 'rows' => 20)),
         'format_field'         => 'descriptionFormatter',
@@ -127,6 +127,7 @@ Alternatively you can specify custom return image format per field:
 .. code-block:: php
 
     <?php
+    use Sonata\FormatterBundle\Form\Type\SimpleFormatterType;
 
     // ...
 

--- a/docs/reference/formatter_widget.rst
+++ b/docs/reference/formatter_widget.rst
@@ -15,8 +15,9 @@ The ``sonata_simple_formatter_type_selector`` widget has been implemented to all
 .. code-block:: php
 
     <?php
+    use Sonata\FormatterBundle\Form\Type\SimpleFormatterType;
 
-    $formMapper->add('comment', 'sonata_simple_formatter_type', array(
+    $formMapper->add('comment', SimpleFormatterType::class, array(
         'format' => 'markdown',
         'ckeditor_context' => 'default', // optional
     ));
@@ -65,9 +66,10 @@ Now, let's define a form to edit this post:
 .. code-block:: php
 
     <?php
+    use Sonata\FormatterBundle\Form\Type\FormatterType;
 
     $formBuilder
-        ->add('content', 'sonata_formatter_type', array(
+        ->add('content', FormatterType::class, array(
             'event_dispatcher' => $formBuilder->getEventDispatcher(),
             'format_field'   => 'contentFormatter',
             'format_field_options' => array(

--- a/docs/reference/usage.rst
+++ b/docs/reference/usage.rst
@@ -37,9 +37,11 @@ And initialize a form type:
 .. code-block:: php
 
     <?php
+    use Sonata\FormatterBundle\Form\Type\FormatterType;
+
     $formBuilder
         ->add('rawContent') // source content
-        ->add('contentFormatter', 'sonata_formatter_type', array(
+        ->add('contentFormatter', FormatterType::class, array(
             'source_field' => 'rawContent',
             'target_field' => 'content'
         ))

--- a/src/Block/FormatterBlockService.php
+++ b/src/Block/FormatterBlockService.php
@@ -15,7 +15,9 @@ use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Block\Service\AbstractAdminBlockService;
 use Sonata\BlockBundle\Model\BlockInterface;
+use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
 use Sonata\CoreBundle\Model\Metadata;
+use Sonata\FormatterBundle\Form\Type\FormatterType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -41,9 +43,9 @@ class FormatterBlockService extends AbstractAdminBlockService
      */
     public function buildEditForm(FormMapper $formMapper, BlockInterface $block)
     {
-        $formMapper->add('settings', 'sonata_type_immutable_array', [
+        $formMapper->add('settings', ImmutableArrayType::class, [
             'keys' => [
-                ['content', 'sonata_formatter_type', function (FormBuilderInterface $formBuilder) {
+                ['content', FormatterType::class, function (FormBuilderInterface $formBuilder) {
                     return [
                         'event_dispatcher' => $formBuilder->getEventDispatcher(),
                         'format_field' => ['format', '[format]'],

--- a/src/Form/Type/FormatterType.php
+++ b/src/Form/Type/FormatterType.php
@@ -18,6 +18,9 @@ use Sonata\FormatterBundle\Form\EventListener\FormatterListener;
 use Sonata\FormatterBundle\Formatter\Pool;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormInterface;
@@ -95,7 +98,7 @@ class FormatterType extends AbstractType
             $options['source_field_options']['property_path'] = $sourceField;
         }
 
-        $builder->add($formatField, 'choice', $options['format_field_options']);
+        $builder->add($formatField, ChoiceType::class, $options['format_field_options']);
 
         // If there's only one possible format, do not display the choices
         $formatChoices = $builder->get($formatField)->getOption('choices');
@@ -106,11 +109,11 @@ class FormatterType extends AbstractType
             $builder->remove($formatField);
 
             // Replace it with an hidden field
-            $builder->add($formatField, 'hidden', $options['format_field_options']);
+            $builder->add($formatField, HiddenType::class, $options['format_field_options']);
         }
 
         $builder
-            ->add($sourceField, 'textarea', $options['source_field_options']);
+            ->add($sourceField, TextareaType::class, $options['source_field_options']);
 
         /*
          * The listener option only work if the source field is after the current field
@@ -216,8 +219,7 @@ class FormatterType extends AbstractType
             'choices' => $formatters,
         ];
 
-        // NEXT_MAJOR: Remove the method_exists hack when dropping support for symfony < 2.7
-        if (count($formatters) > 1 && method_exists('Symfony\Component\Form\AbstractType', 'configureOptions')) {
+        if (count($formatters) > 1) {
             $formatFieldOptions['choice_translation_domain'] = false;
         }
 

--- a/src/Form/Type/SimpleFormatterType.php
+++ b/src/Form/Type/SimpleFormatterType.php
@@ -15,6 +15,7 @@ use Ivory\CKEditorBundle\Model\ConfigManagerInterface;
 use Ivory\CKEditorBundle\Model\PluginManagerInterface;
 use Ivory\CKEditorBundle\Model\TemplateManagerInterface;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -133,10 +134,7 @@ class SimpleFormatterType extends AbstractType
      */
     public function getParent()
     {
-        // NEXT_MAJOR: Remove ternary (when requirement of Symfony is >= 2.8)
-        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Symfony\Component\Form\Extension\Core\Type\TextareaType'
-            : 'textarea';
+        return TextareaType::class;
     }
 
     /**

--- a/tests/Form/Type/FormatterTypeTest.php
+++ b/tests/Form/Type/FormatterTypeTest.php
@@ -13,6 +13,8 @@ namespace Sonata\FormatterBundle\Tests\Form\Type;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\FormatterBundle\Form\Type\FormatterType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormView;
 
 /**
@@ -115,13 +117,13 @@ class FormatterTypeTest extends TestCase
         ];
 
         $formBuilder = $this->createMock('Symfony\Component\Form\FormBuilderInterface');
-        $formBuilder->expects($this->at(0))->method('add')->with('SomeFormatField', 'choice', [
+        $formBuilder->expects($this->at(0))->method('add')->with('SomeFormatField', ChoiceType::class, [
             'property_path' => 'SomeFormatField',
             'data' => $selectedFormat,
             'choices' => $formatters,
         ]);
         $formBuilder->expects($this->at(1))->method('get')->will($this->returnValue($choiceFormBuilder));
-        $formBuilder->expects($this->at(2))->method('add')->with('SomeSourceField', 'textarea', [
+        $formBuilder->expects($this->at(2))->method('add')->with('SomeSourceField', TextareaType::class, [
             'property_path' => 'SomeSourceField',
         ]);
 
@@ -147,13 +149,13 @@ class FormatterTypeTest extends TestCase
         $choiceFormBuilder->expects($this->once())->method('getOption')->with('choices')->will($this->returnValue($formatters));
 
         $formBuilder = $this->createMock('Symfony\Component\Form\FormBuilderInterface');
-        $formBuilder->expects($this->at(0))->method('add')->with('SomeFormatField', 'choice', [
+        $formBuilder->expects($this->at(0))->method('add')->with('SomeFormatField', ChoiceType::class, [
             'property_path' => 'SomeFormatField',
             'data' => $defaultFormatter,
             'choices' => $formatters,
         ]);
         $formBuilder->expects($this->at(1))->method('get')->will($this->returnValue($choiceFormBuilder));
-        $formBuilder->expects($this->at(2))->method('add')->with('SomeSourceField', 'textarea', [
+        $formBuilder->expects($this->at(2))->method('add')->with('SomeSourceField', TextareaType::class, [
             'property_path' => 'SomeSourceField',
         ]);
 
@@ -193,13 +195,13 @@ class FormatterTypeTest extends TestCase
         $choiceFormBuilder->expects($this->once())->method('getOption')->with('choices')->will($this->returnValue($formatters));
 
         $formBuilder = $this->createMock('Symfony\Component\Form\FormBuilderInterface');
-        $formBuilder->expects($this->at(0))->method('add')->with('SomeFormatField', 'choice', [
+        $formBuilder->expects($this->at(0))->method('add')->with('SomeFormatField', ChoiceType::class, [
             'property_path' => 'SomeFormatField',
             'data' => $defaultFormatter,
             'choices' => $formatters,
         ]);
         $formBuilder->expects($this->at(1))->method('get')->will($this->returnValue($choiceFormBuilder));
-        $formBuilder->expects($this->at(2))->method('add')->with('SomeSourceField', 'textarea', [
+        $formBuilder->expects($this->at(2))->method('add')->with('SomeSourceField', TextareaType::class, [
             'property_path' => 'SomeSourceField',
         ]);
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataFormatterBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.
<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
 - Removed BC layer for older symfony versions
```
