### PR TITLE
Fix twig 2.x deprecated use of _self

### DIFF
--- a/Resources/views/Ckeditor/browser.html.twig
+++ b/Resources/views/Ckeditor/browser.html.twig
@@ -46,6 +46,7 @@ file that was distributed with this source code.
 
 {% import _self as tree %}
 {% macro navigate_child(collection, admin, root, current_category, depth) %}
+    {% import _self as tree %}
     {% if root and collection|length == 0 %}
         <div>
             <p class="bg-warning">{{ admin.trans('warning_no_category', {}, admin.translationdomain) }}</p>
@@ -60,7 +61,7 @@ file that was distributed with this source code.
                 </div>
 
                 {% if element.children|length %}
-                    {{ _self.navigate_child(element.children, admin, false, current_category, depth + 1) }}
+                    {{ tree.navigate_child(element.children, admin, false, current_category, depth + 1) }}
                 {% endif %}
             </li>
         {% endfor %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataFormatterBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it's a bug fix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.

Closes #{put_issue_number_here}
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fix the deprecated use of _self in twig template
```
## Subject

In twig 2.x, `_self` returns the template name and need to be fix in this view.
