### PR TITLE
Use FormRenderer runtime to maintain compatibility with Symfony 3.4

### DIFF
--- a/src/Controller/CkeditorAdminController.php
+++ b/src/Controller/CkeditorAdminController.php
@@ -13,6 +13,11 @@ namespace Sonata\FormatterBundle\Controller;
 
 use Sonata\MediaBundle\Controller\MediaAdminController;
 use Sonata\MediaBundle\Provider\MediaProviderInterface;
+use Symfony\Bridge\Twig\AppVariable;
+use Symfony\Bridge\Twig\Command\DebugCommand;
+use Symfony\Bridge\Twig\Extension\FormExtension;
+use Symfony\Bridge\Twig\Form\TwigRenderer;
+use Symfony\Component\Form\FormRenderer;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -187,12 +192,19 @@ class CkeditorAdminController extends MediaAdminController
         $twig = $this->get('twig');
 
         // BC for Symfony < 3.2 where this runtime does not exists
-        if (!method_exists('Symfony\Bridge\Twig\AppVariable', 'getToken')) {
-            $twig->getExtension('Symfony\Bridge\Twig\Extension\FormExtension')
-                ->renderer->setTheme($formView, $theme);
+        if (!method_exists(AppVariable::class, 'getToken')) {
+            $twig->getExtension(FormExtension::class)->renderer->setTheme($formView, $theme);
 
             return;
         }
-        $twig->getRuntime('Symfony\Bridge\Twig\Form\TwigRenderer')->setTheme($formView, $theme);
+
+        // BC for Symfony < 3.4 where runtime should be TwigRenderer
+        if (!method_exists(DebugCommand::class, 'getLoaderPaths')) {
+            $twig->getRuntime(TwigRenderer::class)->setTheme($formView, $theme);
+
+            return;
+        }
+
+        $twig->getRuntime(FormRenderer::class)->setTheme($formView, $theme);
     }
 }

--- a/tests/Controller/CkeditorAdminControllerTest.php
+++ b/tests/Controller/CkeditorAdminControllerTest.php
@@ -14,6 +14,11 @@ namespace Sonata\FormatterBundle\Tests\Controller;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Sonata\FormatterBundle\Controller\CkeditorAdminController;
+use Symfony\Bridge\Twig\AppVariable;
+use Symfony\Bridge\Twig\Command\DebugCommand;
+use Symfony\Bridge\Twig\Extension\FormExtension;
+use Symfony\Bridge\Twig\Form\TwigRenderer;
+use Symfony\Component\Form\FormRenderer;
 
 class EntityWithGetId
 {
@@ -149,21 +154,27 @@ class CkeditorAdminControllerTest extends TestCase
 
     private function configureSetFormTheme($formView, $formTheme)
     {
-        $twig = $this->prophesize('\Twig_Environment');
-        $twigRenderer = $this->prophesize('Symfony\Bridge\Twig\Form\TwigRenderer');
+        $twig = $this->prophesize(\Twig_Environment::class);
+
+        // Remove this trick when bumping Symfony requirement to 3.4+
+        if (method_exists(DebugCommand::class, 'getLoaderPaths')) {
+            $rendererClass = FormRenderer::class;
+        } else {
+            $rendererClass = TwigRenderer::class;
+        }
+
+        $twigRenderer = $this->prophesize($rendererClass);
 
         $this->container->get('twig')->willReturn($twig->reveal());
 
         // Remove this trick when bumping Symfony requirement to 3.2+.
-        if (method_exists('Symfony\Bridge\Twig\AppVariable', 'getToken')) {
-            $twig->getRuntime('Symfony\Bridge\Twig\Form\TwigRenderer')->willReturn($twigRenderer->reveal());
+        if (method_exists(AppVariable::class, 'getToken')) {
+            $twig->getRuntime($rendererClass)->willReturn($twigRenderer->reveal());
         } else {
-            $formExtension = $this->prophesize('Symfony\Bridge\Twig\Extension\FormExtension');
+            $formExtension = $this->prophesize(FormExtension::class);
             $formExtension->renderer = $twigRenderer->reveal();
 
-            // This Throw is for the CRUDController::setFormTheme()
-            $twig->getRuntime('Symfony\Bridge\Twig\Form\TwigRenderer')->willThrow('\Twig_Error_Runtime');
-            $twig->getExtension('Symfony\Bridge\Twig\Extension\FormExtension')->willReturn($formExtension->reveal());
+            $twig->getExtension(FormExtension::class)->willReturn($formExtension->reveal());
         }
         $twigRenderer->setTheme($formView, $formTheme)->shouldBeCalled();
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fix for getRuntime on Symfony older than 3.4
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [x] Update the tests

## Subject

<!-- Describe your Pull Request content here -->
TwigRenderer is used as runtime until SF 3.4.
This code makes sure we retrieve the correct runtime for SF < 3.4