### PR TITLE
Remove tautologies

### DIFF
--- a/src/Admin/CkeditorAdminExtension.php
+++ b/src/Admin/CkeditorAdminExtension.php
@@ -22,9 +22,6 @@ use Sonata\AdminBundle\Route\RouteCollection;
  */
 class CkeditorAdminExtension extends AbstractAdminExtension
 {
-    /**
-     * {@inheritdoc}
-     */
     public function configureRoutes(AdminInterface $admin, RouteCollection $collection)
     {
         $collection->add('ckeditor_browser', 'ckeditor_browser', [

--- a/src/Block/FormatterBlockService.php
+++ b/src/Block/FormatterBlockService.php
@@ -27,9 +27,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class FormatterBlockService extends AbstractAdminBlockService
 {
-    /**
-     * {@inheritdoc}
-     */
     public function execute(BlockContextInterface $blockContext, Response $response = null)
     {
         return $this->renderResponse($blockContext->getTemplate(), [
@@ -38,9 +35,6 @@ class FormatterBlockService extends AbstractAdminBlockService
         ], $response);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function buildEditForm(FormMapper $formMapper, BlockInterface $block)
     {
         $formMapper->add('settings', ImmutableArrayType::class, [
@@ -59,9 +53,6 @@ class FormatterBlockService extends AbstractAdminBlockService
         ]);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function configureSettings(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
@@ -72,9 +63,6 @@ class FormatterBlockService extends AbstractAdminBlockService
         ]);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getBlockMetadata($code = null)
     {
         return new Metadata($this->getName(), (null !== $code ? $code : $this->getName()), false, 'SonataFormatterBundle', [

--- a/src/Controller/CkeditorAdminController.php
+++ b/src/Controller/CkeditorAdminController.php
@@ -26,8 +26,6 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 class CkeditorAdminController extends MediaAdminController
 {
     /**
-     * Returns the response object associated with the browser action.
-     *
      * @throws AccessDeniedException
      *
      * @return Response
@@ -99,8 +97,6 @@ class CkeditorAdminController extends MediaAdminController
     }
 
     /**
-     * Returns the response object associated with the upload action.
-     *
      * @throws AccessDeniedException
      * @throws NotFoundHttpException
      *
@@ -150,10 +146,6 @@ class CkeditorAdminController extends MediaAdminController
     }
 
     /**
-     * Returns a template.
-     *
-     * @param string $name
-     *
      * @return string
      */
     private function getTemplate($name)
@@ -181,9 +173,6 @@ class CkeditorAdminController extends MediaAdminController
 
     /**
      * Sets the admin form theme to form view. Used for compatibility between Symfony versions.
-     *
-     * @param FormView $formView
-     * @param string   $theme
      */
     private function setFormTheme(FormView $formView, $theme)
     {

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -22,9 +22,6 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  */
 class Configuration implements ConfigurationInterface
 {
-    /**
-     * {@inheritdoc}
-     */
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
@@ -52,11 +49,6 @@ class Configuration implements ConfigurationInterface
         return $treeBuilder;
     }
 
-    /**
-     * Adds CKEditor configuration section to root node configuration.
-     *
-     * @param ArrayNodeDefinition $node
-     */
     private function addCkeditorSection(ArrayNodeDefinition $node)
     {
         $node

--- a/src/DependencyInjection/SonataFormatterExtension.php
+++ b/src/DependencyInjection/SonataFormatterExtension.php
@@ -26,9 +26,6 @@ class SonataFormatterExtension extends Extension
 {
     /**
      * Loads the url shortener configuration.
-     *
-     * @param array            $configs   An array of configuration settings
-     * @param ContainerBuilder $container A ContainerBuilder instance
      */
     public function load(array $configs, ContainerBuilder $container)
     {
@@ -103,10 +100,7 @@ class SonataFormatterExtension extends Extension
     }
 
     /**
-     * @param ContainerBuilder $container
-     * @param string           $code
-     * @param Definition       $formatter
-     * @param array            $extensions
+     * @param string $code
      *
      * @return string
      */
@@ -167,25 +161,16 @@ class SonataFormatterExtension extends Extension
         return sprintf('sonata.formatter.twig.env.%s', $code);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getXsdValidationBasePath()
     {
         return __DIR__.'/../Resources/config/schema';
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getNamespace()
     {
         return 'http://www.sonata-project.org/schema/dic/formatter';
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getAlias()
     {
         return 'sonata_formatter';

--- a/src/Extension/BaseExtension.php
+++ b/src/Extension/BaseExtension.php
@@ -15,105 +15,66 @@ use Twig_Environment;
 
 abstract class BaseExtension extends \Twig_Extension implements ExtensionInterface
 {
-    /**
-     * {@inheritdoc}
-     */
     public function getAllowedFilters()
     {
         return [];
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getAllowedTags()
     {
         return [];
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getAllowedFunctions()
     {
         return [];
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getAllowedProperties()
     {
         return [];
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getAllowedMethods()
     {
         return [];
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function initRuntime(Twig_Environment $environment)
     {
         return [];
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getTokenParsers()
     {
         return [];
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getNodeVisitors()
     {
         return [];
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getFilters()
     {
         return [];
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getTests()
     {
         return [];
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getFunctions()
     {
         return [];
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getOperators()
     {
         return [];
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getGlobals()
     {
         return [];

--- a/src/Extension/BaseExtension.php
+++ b/src/Extension/BaseExtension.php
@@ -11,9 +11,10 @@
 
 namespace Sonata\FormatterBundle\Extension;
 
-use Twig_Environment;
+use Twig\Environment;
+use Twig\Extension\AbstractExtension;
 
-abstract class BaseExtension extends \Twig_Extension implements ExtensionInterface
+abstract class BaseExtension extends AbstractExtension implements ExtensionInterface
 {
     public function getAllowedFilters()
     {
@@ -40,7 +41,7 @@ abstract class BaseExtension extends \Twig_Extension implements ExtensionInterfa
         return [];
     }
 
-    public function initRuntime(Twig_Environment $environment)
+    public function initRuntime(Environment $environment)
     {
         return [];
     }

--- a/src/Extension/BaseProxyExtension.php
+++ b/src/Extension/BaseProxyExtension.php
@@ -11,9 +11,10 @@
 
 namespace Sonata\FormatterBundle\Extension;
 
-use Twig_Environment;
+use Twig\Environment;
+use Twig\Extension\AbstractExtension;
 
-abstract class BaseProxyExtension extends \Twig_Extension implements ExtensionInterface
+abstract class BaseProxyExtension extends AbstractExtension implements ExtensionInterface
 {
     /**
      * @return \Twig_ExtensionInterface
@@ -45,7 +46,7 @@ abstract class BaseProxyExtension extends \Twig_Extension implements ExtensionIn
         return [];
     }
 
-    public function initRuntime(Twig_Environment $environment)
+    public function initRuntime(Environment $environment)
     {
         $this->getTwigExtension()->initRuntime($environment);
     }

--- a/src/Extension/BaseProxyExtension.php
+++ b/src/Extension/BaseProxyExtension.php
@@ -20,105 +20,66 @@ abstract class BaseProxyExtension extends \Twig_Extension implements ExtensionIn
      */
     abstract public function getTwigExtension();
 
-    /**
-     * {@inheritdoc}
-     */
     public function getAllowedFilters()
     {
         return [];
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getAllowedTags()
     {
         return [];
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getAllowedFunctions()
     {
         return [];
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getAllowedProperties()
     {
         return [];
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getAllowedMethods()
     {
         return [];
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function initRuntime(Twig_Environment $environment)
     {
         $this->getTwigExtension()->initRuntime($environment);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getTokenParsers()
     {
         return $this->getTwigExtension()->getTokenParsers();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getNodeVisitors()
     {
         return $this->getTwigExtension()->getNodeVisitors();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getFilters()
     {
         return $this->getTwigExtension()->getFilters();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getTests()
     {
         return $this->getTwigExtension()->getTests();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getFunctions()
     {
         return $this->getTwigExtension()->getFunctions();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getOperators()
     {
         return $this->getTwigExtension()->getOperators();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getGlobals()
     {
         return $this->getTwigExtension()->getGlobals();

--- a/src/Extension/ControlFlowExtension.php
+++ b/src/Extension/ControlFlowExtension.php
@@ -13,9 +13,6 @@ namespace Sonata\FormatterBundle\Extension;
 
 class ControlFlowExtension extends BaseExtension
 {
-    /**
-     * {@inheritdoc}
-     */
     public function getAllowedFilters()
     {
         return [
@@ -23,9 +20,6 @@ class ControlFlowExtension extends BaseExtension
         ];
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getAllowedTags()
     {
         return [
@@ -34,17 +28,11 @@ class ControlFlowExtension extends BaseExtension
         ];
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getAllowedFunctions()
     {
         return [];
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getName()
     {
         return 'sonata_formatter_extension_flow';

--- a/src/Extension/ExtensionInterface.php
+++ b/src/Extension/ExtensionInterface.php
@@ -14,42 +14,26 @@ namespace Sonata\FormatterBundle\Extension;
 interface ExtensionInterface
 {
     /**
-     * Returns an array of available filters.
-     *
-     * @abstract
-     *
      * @return array
      */
     public function getAllowedFilters();
 
     /**
-     * Returns an array of available tags.
-     *
-     * @abstract
-     *
      * @return array
      */
     public function getAllowedTags();
 
     /**
-     * Returns an array of available functions.
-     *
-     * @abstract
-     *
      * @return array
      */
     public function getAllowedFunctions();
 
     /**
-     * @abstract
-     *
      * @return array
      */
     public function getAllowedProperties();
 
     /**
-     * @abstract
-     *
      * @return array
      */
     public function getAllowedMethods();

--- a/src/Extension/GistExtension.php
+++ b/src/Extension/GistExtension.php
@@ -15,17 +15,11 @@ use Sonata\FormatterBundle\Twig\TokenParser\GistTokenParser;
 
 class GistExtension extends BaseExtension
 {
-    /**
-     * {@inheritdoc}
-     */
     public function getAllowedFilters()
     {
         return [];
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getAllowedTags()
     {
         return [
@@ -33,17 +27,11 @@ class GistExtension extends BaseExtension
         ];
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getAllowedFunctions()
     {
         return [];
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getTokenParsers()
     {
         return [
@@ -51,9 +39,6 @@ class GistExtension extends BaseExtension
         ];
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getName()
     {
         return 'sonata_formatter_extension_gist';

--- a/src/Form/EventListener/FormatterListener.php
+++ b/src/Form/EventListener/FormatterListener.php
@@ -38,7 +38,6 @@ class FormatterListener
     protected $targetField;
 
     /**
-     * @param Pool   $pool
      * @param string $formatField
      * @param string $sourceField
      * @param string $targetField
@@ -52,9 +51,6 @@ class FormatterListener
         $this->targetField = $targetField;
     }
 
-    /**
-     * @param FormEvent $event
-     */
     public function postSubmit(FormEvent $event)
     {
         $accessor = PropertyAccess::createPropertyAccessor();

--- a/src/Form/Type/FormatterType.php
+++ b/src/Form/Type/FormatterType.php
@@ -26,7 +26,6 @@ use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
 class FormatterType extends AbstractType
@@ -189,15 +188,6 @@ class FormatterType extends AbstractType
         $view->vars['source_id'] = str_replace($view->vars['name'], $view->vars['source_field'], $view->vars['id']);
     }
 
-    /**
-     * NEXT_MAJOR: Remove this method when dropping support for symfony 2.*.
-     *
-     * {@inheritdoc}
-     */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
-    {
-        $this->configureOptions($resolver);
-    }
     public function configureOptions(OptionsResolver $resolver)
     {
         $pool = $this->pool;

--- a/src/Form/Type/FormatterType.php
+++ b/src/Form/Type/FormatterType.php
@@ -57,14 +57,17 @@ class FormatterType extends AbstractType
     private $templateManager;
 
     /**
-     * @param Pool                     $pool            A Formatter Pool service
-     * @param TranslatorInterface      $translator      A Symfony Translator service
-     * @param ConfigManagerInterface   $configManager   An Ivory CKEditor bundle configuration manager
-     * @param PluginManagerInterface   $pluginManager   An Ivory CKEditor bundle plugin manager
-     * @param TemplateManagerInterface $templateManager An Ivory CKEditor bundle template manager
+     * @param ConfigManagerInterface|null   $configManager   An Ivory CKEditor bundle configuration manager
+     * @param PluginManagerInterface|null   $pluginManager   An Ivory CKEditor bundle plugin manager
+     * @param TemplateManagerInterface|null $templateManager An Ivory CKEditor bundle template manager
      */
-    public function __construct(Pool $pool, TranslatorInterface $translator, ConfigManagerInterface $configManager, PluginManagerInterface $pluginManager = null, TemplateManagerInterface $templateManager = null)
-    {
+    public function __construct(
+        Pool $pool,
+        TranslatorInterface $translator,
+        ConfigManagerInterface $configManager,
+        PluginManagerInterface $pluginManager = null,
+        TemplateManagerInterface $templateManager = null
+    ) {
         $this->pool = $pool;
         $this->translator = $translator;
         $this->configManager = $configManager;
@@ -72,9 +75,6 @@ class FormatterType extends AbstractType
         $this->templateManager = $templateManager;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         if (is_array($options['format_field'])) {
@@ -134,9 +134,6 @@ class FormatterType extends AbstractType
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
         if (is_array($options['source_field'])) {
@@ -201,10 +198,6 @@ class FormatterType extends AbstractType
     {
         $this->configureOptions($resolver);
     }
-
-    /**
-     * {@inheritdoc}
-     */
     public function configureOptions(OptionsResolver $resolver)
     {
         $pool = $this->pool;
@@ -257,17 +250,11 @@ class FormatterType extends AbstractType
         ]);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getBlockPrefix()
     {
         return 'sonata_formatter_type';
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getName()
     {
         return $this->getBlockPrefix();

--- a/src/Form/Type/SimpleFormatterType.php
+++ b/src/Form/Type/SimpleFormatterType.php
@@ -39,20 +39,20 @@ class SimpleFormatterType extends AbstractType
     private $templateManager;
 
     /**
-     * @param ConfigManagerInterface   $configManager   An Ivory CKEditor bundle configuration manager
-     * @param PluginManagerInterface   $pluginManager   An Ivory CKEditor bundle plugin manager
-     * @param TemplateManagerInterface $templateManager An Ivory CKEditor bundle template manager
+     * @param ConfigManagerInterface        $configManager   An Ivory CKEditor bundle configuration manager
+     * @param PluginManagerInterface|null   $pluginManager   An Ivory CKEditor bundle plugin manager
+     * @param TemplateManagerInterface|null $templateManager An Ivory CKEditor bundle template manager
      */
-    public function __construct(ConfigManagerInterface $configManager, PluginManagerInterface $pluginManager = null, TemplateManagerInterface $templateManager = null)
-    {
+    public function __construct(
+        ConfigManagerInterface $configManager,
+        PluginManagerInterface $pluginManager = null,
+        TemplateManagerInterface $templateManager = null
+    ) {
         $this->configManager = $configManager;
         $this->pluginManager = $pluginManager;
         $this->templateManager = $templateManager;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
         $ckeditorConfiguration = [
@@ -128,26 +128,16 @@ class SimpleFormatterType extends AbstractType
     {
         $this->configureOptions($resolver);
     }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getParent()
     {
         return TextareaType::class;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getBlockPrefix()
     {
         return 'sonata_simple_formatter_type';
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getName()
     {
         return $this->getBlockPrefix();

--- a/src/Form/Type/SimpleFormatterType.php
+++ b/src/Form/Type/SimpleFormatterType.php
@@ -19,7 +19,6 @@ use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 class SimpleFormatterType extends AbstractType
 {
@@ -119,15 +118,6 @@ class SimpleFormatterType extends AbstractType
         ]);
     }
 
-    /**
-     * For Symfony <= 2.8.
-     *
-     * @param OptionsResolverInterface $resolver
-     */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
-    {
-        $this->configureOptions($resolver);
-    }
     public function getParent()
     {
         return TextareaType::class;

--- a/src/Formatter/BaseFormatter.php
+++ b/src/Formatter/BaseFormatter.php
@@ -20,9 +20,6 @@ abstract class BaseFormatter implements FormatterInterface
      */
     protected $extensions = [];
 
-    /**
-     * @param ExtensionInterface $extensionInterface
-     */
     public function addExtension(ExtensionInterface $extensionInterface)
     {
         $this->extensions[] = $extensionInterface;

--- a/src/Formatter/FormatterInterface.php
+++ b/src/Formatter/FormatterInterface.php
@@ -20,9 +20,6 @@ interface FormatterInterface
      */
     public function transform($text);
 
-    /**
-     * @param ExtensionInterface $extensionInterface
-     */
     public function addExtension(ExtensionInterface $extensionInterface);
 
     /**

--- a/src/Formatter/MarkdownFormatter.php
+++ b/src/Formatter/MarkdownFormatter.php
@@ -20,17 +20,11 @@ class MarkdownFormatter extends BaseFormatter
      */
     protected $parser;
 
-    /**
-     * @param MarkdownParserInterface $parser
-     */
     public function __construct(MarkdownParserInterface $parser)
     {
         $this->parser = $parser;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function transform($text)
     {
         return $this->parser->transformMarkdown($text);

--- a/src/Formatter/Pool.php
+++ b/src/Formatter/Pool.php
@@ -88,9 +88,7 @@ class Pool implements LoggerAwareInterface
     }
 
     /**
-     * @param string                 $code
-     * @param FormatterInterface     $formatter
-     * @param \Twig_Environment|null $env
+     * @param string $code
      */
     public function add($code, FormatterInterface $formatter, Twig_Environment $env = null)
     {

--- a/src/Formatter/Pool.php
+++ b/src/Formatter/Pool.php
@@ -14,9 +14,9 @@ namespace Sonata\FormatterBundle\Formatter;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
-use Twig_Environment;
-use Twig_Error_Syntax;
-use Twig_Sandbox_SecurityError;
+use Twig\Environment;
+use Twig\Error\SyntaxError;
+use Twig\Sandbox\SecurityError;
 
 class Pool implements LoggerAwareInterface
 {
@@ -90,7 +90,7 @@ class Pool implements LoggerAwareInterface
     /**
      * @param string $code
      */
-    public function add($code, FormatterInterface $formatter, Twig_Environment $env = null)
+    public function add($code, FormatterInterface $formatter, Environment $env = null)
     {
         $this->formatters[$code] = [$formatter, $env];
     }
@@ -143,7 +143,7 @@ class Pool implements LoggerAwareInterface
                     $text = $env->render($text);
                 }
             }
-        } catch (Twig_Error_Syntax $e) {
+        } catch (SyntaxError $e) {
             $this->logger->critical(sprintf(
                 '[FormatterBundle::transform] %s - Error while parsing twig template : %s',
                 $code,
@@ -152,7 +152,7 @@ class Pool implements LoggerAwareInterface
                 'text' => $text,
                 'exception' => $e,
             ]);
-        } catch (Twig_Sandbox_SecurityError $e) {
+        } catch (SecurityError $e) {
             $this->logger->critical(sprintf(
                 '[FormatterBundle::transform] %s - the user try an non white-listed keyword : %s',
                 $code,

--- a/src/Formatter/RawFormatter.php
+++ b/src/Formatter/RawFormatter.php
@@ -13,9 +13,6 @@ namespace Sonata\FormatterBundle\Formatter;
 
 class RawFormatter extends BaseFormatter
 {
-    /**
-     * {@inheritdoc}
-     */
     public function transform($text)
     {
         return $text;

--- a/src/Formatter/TextFormatter.php
+++ b/src/Formatter/TextFormatter.php
@@ -13,9 +13,6 @@ namespace Sonata\FormatterBundle\Formatter;
 
 class TextFormatter extends BaseFormatter
 {
-    /**
-     * {@inheritdoc}
-     */
     public function transform($text)
     {
         return nl2br($text);

--- a/src/Formatter/TwigFormatter.php
+++ b/src/Formatter/TwigFormatter.php
@@ -12,15 +12,18 @@
 namespace Sonata\FormatterBundle\Formatter;
 
 use Sonata\FormatterBundle\Extension\ExtensionInterface;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+use Twig\Loader\ChainLoader;
 
-class TwigFormatter implements \Sonata\FormatterBundle\Formatter\FormatterInterface
+class TwigFormatter implements FormatterInterface
 {
     /**
-     * @var \Twig_Environment
+     * @var Environment
      */
     protected $twig;
 
-    public function __construct(\Twig_Environment $twig)
+    public function __construct(Environment $twig)
     {
         $this->twig = $twig;
     }
@@ -33,8 +36,8 @@ class TwigFormatter implements \Sonata\FormatterBundle\Formatter\FormatterInterf
 
         $hash = sha1($text);
 
-        $chainLoader = new \Twig_Loader_Chain();
-        $chainLoader->addLoader(new \Twig_Loader_Array([$hash => $text]));
+        $chainLoader = new ChainLoader();
+        $chainLoader->addLoader(new ArrayLoader([$hash => $text]));
         $chainLoader->addLoader($oldLoader);
 
         $this->twig->setLoader($chainLoader);

--- a/src/Formatter/TwigFormatter.php
+++ b/src/Formatter/TwigFormatter.php
@@ -20,9 +20,6 @@ class TwigFormatter implements \Sonata\FormatterBundle\Formatter\FormatterInterf
      */
     protected $twig;
 
-    /**
-     * @param \Twig_Environment $twig
-     */
     public function __construct(\Twig_Environment $twig)
     {
         $this->twig = $twig;

--- a/src/Formatter/TwigFormatter.php
+++ b/src/Formatter/TwigFormatter.php
@@ -25,9 +25,6 @@ class TwigFormatter implements \Sonata\FormatterBundle\Formatter\FormatterInterf
         $this->twig = $twig;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function transform($text)
     {
         // Here we temporary changing twig environment loader to Chain loader with Twig_Loader_Array as first loader,
@@ -49,17 +46,11 @@ class TwigFormatter implements \Sonata\FormatterBundle\Formatter\FormatterInterf
         return $result;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function addExtension(ExtensionInterface $extensionInterface)
     {
         throw new \RuntimeException('\\Sonata\\FormatterBundle\\Formatter\\TwigFormatter cannot have extensions');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getExtensions()
     {
         return [];

--- a/src/SonataFormatterBundle.php
+++ b/src/SonataFormatterBundle.php
@@ -17,25 +17,16 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class SonataFormatterBundle extends Bundle
 {
-    /**
-     * {@inheritdoc}
-     */
     public function build(ContainerBuilder $container)
     {
         $this->registerFormMapping();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function boot()
     {
         $this->registerFormMapping();
     }
 
-    /**
-     * Register form mapping information.
-     */
     public function registerFormMapping()
     {
         FormHelper::registerFormTypeMapping([

--- a/src/Twig/Extension/TextFormatterExtension.php
+++ b/src/Twig/Extension/TextFormatterExtension.php
@@ -25,26 +25,17 @@ class TextFormatterExtension extends AbstractExtension
      */
     protected $pool;
 
-    /**
-     * @param Pool $pool
-     */
     public function __construct(Pool $pool)
     {
         $this->pool = $pool;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getTokenParsers()
     {
         return [
         ];
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getFilters()
     {
         return [
@@ -63,9 +54,6 @@ class TextFormatterExtension extends AbstractExtension
         return $this->pool->transform($type, $text);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getName()
     {
         return 'sonata_text_formatter';

--- a/src/Twig/Loader/LoaderSelector.php
+++ b/src/Twig/Loader/LoaderSelector.php
@@ -16,28 +16,21 @@ use Twig\Loader\LoaderInterface;
 class LoaderSelector implements LoaderInterface
 {
     /**
-     * @var \Twig_LoaderInterface
+     * @var LoaderInterface
      */
     protected $stringLoader;
 
     /**
-     * @var \Twig_LoaderInterface
+     * @var LoaderInterface
      */
     protected $fileLoader;
 
-    /**
-     * @param \Twig_LoaderInterface $stringLoader
-     * @param \Twig_LoaderInterface $fileLoader
-     */
     public function __construct(LoaderInterface $stringLoader, LoaderInterface $fileLoader)
     {
         $this->stringLoader = $stringLoader;
         $this->fileLoader = $fileLoader;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getSource($name)
     {
         $source = $this->getLoader($name)->getSource($name);
@@ -52,41 +45,27 @@ class LoaderSelector implements LoaderInterface
         return $source;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getSourceContext($name)
     {
         return $this->getLoader($name)->getSourceContext($name);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function exists($name)
     {
         return $this->getLoader($name)->exists($name);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getCacheKey($name)
     {
         return $this->getLoader($name)->getCacheKey($name);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function isFresh($name, $time)
     {
         return false;
     }
 
     /**
-     * Finds out the correct loader.
-     *
      * @param string $name
      *
      * @return \Twig_LoaderInterface

--- a/src/Twig/Node/GistNode.php
+++ b/src/Twig/Node/GistNode.php
@@ -18,19 +18,16 @@ use Twig\Node\Node;
 class GistNode extends Node
 {
     /**
-     * @param \Twig_Node_Expression $gist
-     * @param \Twig_Node_Expression $file
-     * @param int                   $lineno
-     * @param string|null           $tag
+     * @param AbstractExpression $gist
+     * @param AbstractExpression $file
+     * @param int                $lineno
+     * @param string|null        $tag
      */
     public function __construct(AbstractExpression $gist, AbstractExpression $file, $lineno, $tag = null)
     {
         parent::__construct(['gist' => $gist, 'file' => $file], [], $lineno, $tag);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function compile(Compiler $compiler)
     {
         $compiler

--- a/src/Twig/Node/GistNode.php
+++ b/src/Twig/Node/GistNode.php
@@ -31,7 +31,11 @@ class GistNode extends Node
     public function compile(Compiler $compiler)
     {
         $compiler
-            ->write(sprintf("echo '<div class=\"sonata-gist\"><script src=\"https://gist.github.com/%s.js?file=%s\"></script></div>';\n",
+            ->write(sprintf(
+                <<<EOT
+echo '<div class="sonata-gist"><script src="https://gist.github.com/%s.js?file=%s"></script></div>';\n,
+EOT
+                ,
                 $this->getNode('gist')->getAttribute('value'),
                 $this->getNode('file')->getAttribute('value')
             ))

--- a/src/Twig/SecurityPolicyContainerAware.php
+++ b/src/Twig/SecurityPolicyContainerAware.php
@@ -63,19 +63,12 @@ class SecurityPolicyContainerAware implements SecurityPolicyInterface
      */
     protected $container;
 
-    /**
-     * @param ContainerInterface $container
-     * @param array              $extensions
-     */
     public function __construct(ContainerInterface $container, array $extensions = [])
     {
         $this->container = $container;
         $this->extensions = $extensions;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function checkSecurity($tags, $filters, $functions)
     {
         $this->buildAllowed();
@@ -99,9 +92,6 @@ class SecurityPolicyContainerAware implements SecurityPolicyInterface
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function checkMethodAllowed($obj, $method)
     {
         $this->buildAllowed();
@@ -131,9 +121,6 @@ class SecurityPolicyContainerAware implements SecurityPolicyInterface
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function checkPropertyAllowed($obj, $property)
     {
         $this->buildAllowed();

--- a/src/Twig/TokenParser/GistTokenParser.php
+++ b/src/Twig/TokenParser/GistTokenParser.php
@@ -17,9 +17,6 @@ use Twig\TokenParser\AbstractTokenParser;
 
 class GistTokenParser extends AbstractTokenParser
 {
-    /**
-     * {@inheritdoc}
-     */
     public function parse(Token $token)
     {
         $gist = $this->parser->getExpressionParser()->parseExpression();
@@ -33,9 +30,6 @@ class GistTokenParser extends AbstractTokenParser
         return new GistNode($gist, $file, $token->getLine(), $this->getTag());
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getTag()
     {
         return 'gist';

--- a/src/Validator/Constraints/Formatter.php
+++ b/src/Validator/Constraints/Formatter.php
@@ -23,17 +23,11 @@ class Formatter extends Constraint
      */
     public $message = 'The formatter is not valid';
 
-    /**
-     * {@inheritdoc}
-     */
     public function validatedBy()
     {
         return 'sonata.formatter.validator.formatter';
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getTargets()
     {
         return self::PROPERTY_CONSTRAINT;

--- a/src/Validator/Constraints/FormatterValidator.php
+++ b/src/Validator/Constraints/FormatterValidator.php
@@ -25,17 +25,11 @@ class FormatterValidator extends ConstraintValidator
      */
     protected $pool;
 
-    /**
-     * @param Pool $pool
-     */
     public function __construct(Pool $pool)
     {
         $this->pool = $pool;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function validate($value, Constraint $constraint)
     {
         if (!$this->pool->has($value)) {


### PR DESCRIPTION
I am targeting this branch, because this is pedantic.

This removes a lot of comments that are just tautological. Also, this migrates more classes to Twig namespaces. I ran my script only on `src/Twig` the other day 😅 