### PR TITLE
Fixed initialisation in sf3+

### DIFF
--- a/docs/reference/formatter_widget.rst
+++ b/docs/reference/formatter_widget.rst
@@ -73,7 +73,10 @@ Now, let's define a form to edit this post:
             'event_dispatcher' => $formBuilder->getEventDispatcher(),
             'format_field'   => 'contentFormatter',
             'format_field_options' => array(
-                'choices' => array('text', 'markdown'),
+                'choices' => [
+                    'text' => 'Text',
+                    'markdown' => 'Markdown',
+                ],
                 'data' => 'markdown',
             ),
             'source_field'   => 'rawContent',

--- a/src/Form/Type/FormatterType.php
+++ b/src/Form/Type/FormatterType.php
@@ -24,6 +24,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -195,7 +196,7 @@ class FormatterType extends AbstractType
 
         $formatters = [];
         foreach ($pool->getFormatters() as $code => $instance) {
-            $formatters[$code] = $translator->trans($code, [], 'SonataFormatterBundle');
+            $formatters[$code] = $code;
         }
 
         $formatFieldOptions = [
@@ -203,7 +204,12 @@ class FormatterType extends AbstractType
         ];
 
         if (count($formatters) > 1) {
-            $formatFieldOptions['choice_translation_domain'] = false;
+            $formatFieldOptions['choice_translation_domain'] = 'SonataFormatterBundle';
+
+            // choices_as_values options is not needed in SF 3.0+
+            if (method_exists(FormTypeInterface::class, 'setDefaultOptions')) {
+                $formatFieldOptions['choices_as_values'] = true;
+            }
         }
 
         $resolver->setDefaults([


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataFormatterBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #236

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
 - Fixed form initialisation in sf3+
```

## Subject

This should fix the init problem in symfony >=3.