### PR TITLE
Declare dependencies explicitly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,9 +28,17 @@
         "knplabs/knp-markdown-bundle": "^1.4",
         "sonata-project/block-bundle": "^3.11",
         "sonata-project/core-bundle": "^3.0",
+        "symfony/config": "^2.8 || ^3.2 || ^4.0",
+        "symfony/dependency-injection": "^2.8 || ^3.2 || ^4.0",
+        "symfony/event-dispatcher": "^2.8 || ^3.2 || ^4.0",
         "symfony/form": "^2.8 || ^3.2 || ^4.0",
         "symfony/framework-bundle": "^2.8 || ^3.2 || ^4.0",
+        "symfony/http-foundation": "^2.8 || ^3.2 || ^4.0",
+        "symfony/http-kernel": "^2.8 || ^3.2 || ^4.0",
+        "symfony/options-resolver": "^2.8 || ^3.2 || ^4.0",
         "symfony/property-access": "^2.8 || ^3.2 || ^4.0",
+        "symfony/translation": "^2.8 || ^3.2 || ^4.0",
+        "symfony/twig-bridge": "^2.8 || ^3.2 || ^4.0",
         "twig/twig": "^1.34 || ^2.0"
     },
     "conflict": {

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "matthiasnoback/symfony-dependency-injection-test": "^1.1",
         "sonata-project/admin-bundle": "^3.11",
         "sonata-project/media-bundle": "^3.10",
-        "symfony/phpunit-bridge": "^3.3 || ^4.0",
+        "symfony/phpunit-bridge": "^4.0",
         "symfony/validator": "^2.8 || ^3.2 || ^4.0"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,9 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "egeloen/ckeditor-bundle": "^4.0 || ^5.0",
-        "knplabs/knp-markdown-bundle": "^1.4",
+        "knplabs/knp-markdown-bundle": "^1.7",
         "sonata-project/block-bundle": "^3.11",
-        "sonata-project/core-bundle": "^3.0",
+        "sonata-project/core-bundle": "^3.9",
         "symfony/config": "^2.8 || ^3.2 || ^4.0",
         "symfony/dependency-injection": "^2.8 || ^3.2 || ^4.0",
         "symfony/event-dispatcher": "^2.8 || ^3.2 || ^4.0",
@@ -47,7 +47,7 @@
     },
     "require-dev": {
         "matthiasnoback/symfony-dependency-injection-test": "^1.1",
-        "sonata-project/admin-bundle": "^3.11",
+        "sonata-project/admin-bundle": "^3.31",
         "sonata-project/media-bundle": "^3.10",
         "symfony/phpunit-bridge": "^4.0",
         "symfony/validator": "^2.8 || ^3.2 || ^4.0"


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataFormatterBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

I consider this fixes this other PR https://github.com/sonata-project/dev-kit/pull/385 (because that was related to this bundle)

## Subject

<!-- Describe your Pull Request content here -->
This changes nothing on what gets installed when using this bundle. But declaring explicit dependencies makes you use the versions correctly even when doing prefer-lowest. That makes the build faster, and improves the consistency on this bundle, because we know what is needed for this bundle to work exactly.

Labelled as pedantic cause it will change nothing for normal users