### PR TITLE
Adding egeloen/ckeditor-bundle 6.0 dependancy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,77 +1,75 @@
 {
-    "name": "sonata-project/formatter-bundle",
-    "type": "symfony-bundle",
-    "description": "Symfony SonataFormatterBundle",
-    "keywords": [
-        "sonata",
-        "formatter",
-        "markdown",
-        "ckeditor",
-        "markitup"
-    ],
-    "homepage": "https://sonata-project.org/bundles/formatter",
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "Thomas Rabaix",
-            "email": "thomas.rabaix@sonata-project.org",
-            "homepage": "https://sonata-project.org"
-        },
-        {
-            "name": "Sonata Community",
-            "homepage": "https://github.com/sonata-project/SonataFormatterBundle/contributors"
-        }
-    ],
-    "require": {
-        "php": "^7.1",
-        "egeloen/ckeditor-bundle": "^4.0 || ^5.0",
-        "knplabs/knp-markdown-bundle": "^1.7",
-        "sonata-project/block-bundle": "^3.11",
-        "sonata-project/core-bundle": "^3.9",
-        "symfony/config": "^2.8 || ^3.2 || ^4.0",
-        "symfony/dependency-injection": "^2.8 || ^3.2 || ^4.0",
-        "symfony/event-dispatcher": "^2.8 || ^3.2 || ^4.0",
-        "symfony/form": "^2.8 || ^3.2 || ^4.0",
-        "symfony/framework-bundle": "^2.8 || ^3.2 || ^4.0",
-        "symfony/http-foundation": "^2.8 || ^3.2 || ^4.0",
-        "symfony/http-kernel": "^2.8 || ^3.2 || ^4.0",
-        "symfony/options-resolver": "^2.8 || ^3.2 || ^4.0",
-        "symfony/property-access": "^2.8 || ^3.2 || ^4.0",
-        "symfony/translation": "^2.8 || ^3.2 || ^4.0",
-        "symfony/twig-bridge": "^2.8 || ^3.2 || ^4.0",
-        "twig/twig": "^1.34 || ^2.0"
-    },
-    "conflict": {
-        "sonata-project/admin-bundle": "<3.0",
-        "sonata-project/media-bundle": "<3.0"
-    },
-    "require-dev": {
-        "matthiasnoback/symfony-dependency-injection-test": "^1.1",
-        "sonata-project/admin-bundle": "^3.31",
-        "sonata-project/media-bundle": "^3.10",
-        "symfony/phpunit-bridge": "^4.0",
-        "symfony/validator": "^2.8 || ^3.2 || ^4.0"
-    },
-    "suggest": {
-        "sonata-project/admin-bundle": "For using the admin media browser.",
-        "sonata-project/media-bundle": "For using the admin media browser."
-    },
-    "config": {
-        "sort-packages": true
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "4.x-dev"
-        }
-    },
-    "autoload": {
-        "psr-4": {
-            "Sonata\\FormatterBundle\\": "src/"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "Sonata\\FormatterBundle\\Tests\\": "tests/"
-        }
-    }
+	"name" : "timwentzell/formatter-bundle",
+	"type" : "symfony-bundle",
+	"description" : "Symfony SonataFormatterBundle",
+	"keywords" : [
+		"sonata",
+		"formatter",
+		"markdown",
+		"ckeditor",
+		"markitup"
+	],
+	"homepage" : "https://sonata-project.org/bundles/formatter",
+	"license" : "MIT",
+	"authors" : [{
+			"name" : "Thomas Rabaix",
+			"email" : "thomas.rabaix@sonata-project.org",
+			"homepage" : "https://sonata-project.org"
+		}, {
+			"name" : "Sonata Community",
+			"homepage" : "https://github.com/sonata-project/SonataFormatterBundle/contributors"
+		}
+	],
+	"require" : {
+		"php" : "^7.1",
+		"egeloen/ckeditor-bundle" : "^4.0 || ^5.0 || ^6.0",
+		"knplabs/knp-markdown-bundle" : "^1.7",
+		"sonata-project/block-bundle" : "^3.11",
+		"sonata-project/core-bundle" : "^3.9",
+		"symfony/config" : "^2.8 || ^3.2 || ^4.0",
+		"symfony/dependency-injection" : "^2.8 || ^3.2 || ^4.0",
+		"symfony/event-dispatcher" : "^2.8 || ^3.2 || ^4.0",
+		"symfony/form" : "^2.8 || ^3.2 || ^4.0",
+		"symfony/framework-bundle" : "^2.8 || ^3.2 || ^4.0",
+		"symfony/http-foundation" : "^2.8 || ^3.2 || ^4.0",
+		"symfony/http-kernel" : "^2.8 || ^3.2 || ^4.0",
+		"symfony/options-resolver" : "^2.8 || ^3.2 || ^4.0",
+		"symfony/property-access" : "^2.8 || ^3.2 || ^4.0",
+		"symfony/translation" : "^2.8 || ^3.2 || ^4.0",
+		"symfony/twig-bridge" : "^2.8 || ^3.2 || ^4.0",
+		"twig/twig" : "^1.34 || ^2.0"
+	},
+	"conflict" : {
+		"sonata-project/admin-bundle" : "<3.0",
+		"sonata-project/media-bundle" : "<3.0"
+	},
+	"require-dev" : {
+		"matthiasnoback/symfony-dependency-injection-test" : "^1.1",
+		"sonata-project/admin-bundle" : "^3.31",
+		"sonata-project/media-bundle" : "^3.10",
+		"symfony/phpunit-bridge" : "^4.0",
+		"symfony/validator" : "^2.8 || ^3.2 || ^4.0"
+	},
+	"suggest" : {
+		"sonata-project/admin-bundle" : "For using the admin media browser.",
+		"sonata-project/media-bundle" : "For using the admin media browser."
+	},
+	"config" : {
+		"sort-packages" : true
+	},
+	"extra" : {
+		"branch-alias" : {
+			"dev-master" : "4.x-dev"
+		}
+	},
+	"autoload" : {
+		"psr-4" : {
+			"Sonata\\FormatterBundle\\" : "src/"
+		}
+	},
+	"autoload-dev" : {
+		"psr-4" : {
+			"Sonata\\FormatterBundle\\Tests\\" : "tests/"
+		}
+	}
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataFormatterBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because {reason}.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #{put_issue_number_here}

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added some `Class::newMethod` to do great stuff

### Changed

### Deprecated

### Removed

### Fixed

### Security
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [ ] Update the tests
- [ ] Update the documentation
- [ ] Add an upgrade note

## Subject

<!-- Describe your Pull Request content here -->
