### PR TITLE
Allowing egeloen/ckeditor-bundle 6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     ],
     "require": {
         "php": "^5.6 || ^7.0",
-        "egeloen/ckeditor-bundle": "^4.0 || ^5.0",
+        "egeloen/ckeditor-bundle": "^4.0 || ^5.0 || ^6.0",
         "knplabs/knp-markdown-bundle": "^1.7",
         "sonata-project/block-bundle": "^3.11",
         "sonata-project/core-bundle": "^3.9",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataFormatterBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a BC fix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #269

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added egeloen/ckeditor-bundle 6.0 dependency to composer.json
```
## Subject

In order to satisfy Symfony 3.4 project dependencies using the SonataFormatterBundle, we require the newest version (6.0) of the egeloen/ckeditor-bundle bundle.
