### PR TITLE
Use renderWithExtraParams() instead of render()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "twig/twig": "^1.34 || ^2.0"
     },
     "conflict": {
-        "sonata-project/admin-bundle": "<3.0",
+        "sonata-project/admin-bundle": "<3.27",
         "sonata-project/media-bundle": "<3.0"
     },
     "require-dev": {

--- a/src/Controller/CkeditorAdminController.php
+++ b/src/Controller/CkeditorAdminController.php
@@ -87,7 +87,7 @@ class CkeditorAdminController extends MediaAdminController
 
         $this->setFormTheme($formView, $this->admin->getFilterTheme());
 
-        return $this->render($this->getTemplate('browser'), [
+        return $this->renderWithExtraParams($this->getTemplate('browser'), [
             'action' => 'browser',
             'form' => $formView,
             'datagrid' => $datagrid,
@@ -138,7 +138,7 @@ class CkeditorAdminController extends MediaAdminController
             $request->get('format', MediaProviderInterface::FORMAT_REFERENCE)
         );
 
-        return $this->render($this->getTemplate('upload'), [
+        return $this->renderWithExtraParams($this->getTemplate('upload'), [
             'action' => 'list',
             'object' => $media,
             'format' => $format,


### PR DESCRIPTION


I am targeting this branch, because this is BC.


## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- deprecations from the admin bundle about `render` vs `renderWithExtraParams`
```
## Subject

render() has been planned for removal and should no longer be used.
