### PR TITLE
Fix ckeditor toolbar config

### DIFF
--- a/src/Resources/config/form_fos.xml
+++ b/src/Resources/config/form_fos.xml
@@ -8,6 +8,7 @@
             <argument type="service" id="fos_ck_editor.config_manager"/>
             <argument type="service" id="fos_ck_editor.plugin_manager"/>
             <argument type="service" id="fos_ck_editor.template_manager"/>
+            <argument type="service" id="fos_ck_editor.toolbar_manager"/>
         </service>
         <service id="sonata.formatter.form.type.simple" class="Sonata\FormatterBundle\Form\Type\SimpleFormatterType">
             <tag name="form.type" alias="sonata_simple_formatter_type"/>
@@ -15,6 +16,7 @@
             <argument type="service" id="fos_ck_editor.plugin_manager"/>
             <argument type="service" id="fos_ck_editor.template_manager"/>
             <argument type="service" id="fos_ck_editor.styles_set_manager"/>
+            <argument type="service" id="fos_ck_editor.toolbar_manager"/>
         </service>
     </services>
 </container>

--- a/src/Resources/config/form_ivory.xml
+++ b/src/Resources/config/form_ivory.xml
@@ -8,6 +8,7 @@
             <argument type="service" id="ivory_ck_editor.config_manager"/>
             <argument type="service" id="ivory_ck_editor.plugin_manager"/>
             <argument type="service" id="ivory_ck_editor.template_manager"/>
+            <argument type="service" id="ivory_ck_editor.toolbar_manager" on-invalid="null"/>
         </service>
         <service id="sonata.formatter.form.type.simple" class="Sonata\FormatterBundle\Form\Type\SimpleFormatterType">
             <tag name="form.type" alias="sonata_simple_formatter_type"/>
@@ -15,6 +16,7 @@
             <argument type="service" id="ivory_ck_editor.plugin_manager"/>
             <argument type="service" id="ivory_ck_editor.template_manager"/>
             <argument type="service" id="ivory_ck_editor.styles_set_manager"/>
+            <argument type="service" id="ivory_ck_editor.toolbar_manager" on-invalid="null"/>
         </service>
     </services>
 </container>


### PR DESCRIPTION
I am targeting this branch, because this is a bug fix and BC.

## Changelog


```markdown
### Fixed
- Ckeditor toolbar config not loading
```

## Subject

v5 of https://github.com/egeloen/IvoryCKEditorBundle introduced a [toolbar manager](https://github.com/egeloen/IvoryCKEditorBundle/commit/7ef1c96f6958b458545f336a10178f033764fd5f) to load the toolbar configuration.

This was never implemented in this bundle although it is compatible with V5 and V6 of the IvoryCKEditorBundle.