### PR TITLE
Remove some typehints

### DIFF
--- a/src/Twig/SecurityPolicyContainerAware.php
+++ b/src/Twig/SecurityPolicyContainerAware.php
@@ -71,7 +71,7 @@ final class SecurityPolicyContainerAware implements SecurityPolicyInterface
         $this->extensions = $extensions;
     }
 
-    public function checkSecurity(array $tags, array $filters, array $functions): void
+    public function checkSecurity($tags, $filters, $functions): void
     {
         $this->buildAllowed();
 
@@ -94,7 +94,7 @@ final class SecurityPolicyContainerAware implements SecurityPolicyInterface
         }
     }
 
-    public function checkMethodAllowed($obj, string $method): bool
+    public function checkMethodAllowed($obj, $method): bool
     {
         $this->buildAllowed();
 

--- a/tests/Formatter/TwigFormatterTest.php
+++ b/tests/Formatter/TwigFormatterTest.php
@@ -56,7 +56,7 @@ class TwigFormatterTest extends TestCase
 
         $extensions = $formatter->getExtensions();
 
-        $this->assertSame(0, count($extensions));
+        $this->assertCount(0, $extensions);
     }
 }
 

--- a/tests/Twig/SecurityPolicyContainerAwareTest.php
+++ b/tests/Twig/SecurityPolicyContainerAwareTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\FormatterBundle\Tests\Twig;
+
+use Phpunit\Framework\TestCase;
+use Sonata\FormatterBundle\Twig\SecurityPolicyContainerAware;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+final class SecurityPolicyContainerAwareTest extends TestCase
+{
+    public function testItCanBeInstantiated(): void
+    {
+        $this->assertInstanceOf(
+            SecurityPolicyContainerAware::class,
+            new SecurityPolicyContainerAware($this->createMock(ContainerInterface::class))
+        );
+    }
+}


### PR DESCRIPTION
In 155337dbece5cbaefac716da7e3b3b93096f7007, I made the wrong assumption
that Twig would have type hints, and introduced a BC break a class that
implements a Twig interface. This removes those type hints, and adds a
test to be sure those cannot be added again by mistake.

I am targeting this branch, because this fix is only relevant on master.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Refs #336 

## Changelog

None, since nothing is released yet.