### PR TITLE
Use correct ExtensionInterface class

### DIFF
--- a/src/Extension/BaseProxyExtension.php
+++ b/src/Extension/BaseProxyExtension.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sonata\FormatterBundle\Extension;
 
 use Twig\Extension\AbstractExtension;
-use Twig\ExtensionInterface;
+use Twig\Extension\ExtensionInterface;
 
 abstract class BaseProxyExtension extends AbstractExtension implements ExtensionInterface
 {


### PR DESCRIPTION
This change is needed because of error in:

https://github.com/sonata-project/SonataMediaBundle/issues/1444

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataFormatterBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because the error appears in Sonata media bundle in the master branch

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Use correct ExtensionInterface class
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->

## Subject

<!-- Describe your Pull Request content here -->
