### PR TITLE
update CKEditor upload to SonataMediaBundle docs

### DIFF
--- a/docs/reference/ckeditor_medias.rst
+++ b/docs/reference/ckeditor_medias.rst
@@ -41,6 +41,7 @@ contain something like this:
                 # Display images by default when clicking the image dialog browse button
                 filebrowserImageBrowseRouteParameters:
                     provider: sonata.media.provider.image
+                filebrowserUploadMethod: form
                 filebrowserUploadRoute: admin_sonata_media_media_ckeditor_upload
                 filebrowserUploadRouteParameters:
                     provider: sonata.media.provider.file

--- a/tests/Formatter/TwigFormatterTest.php
+++ b/tests/Formatter/TwigFormatterTest.php
@@ -54,7 +54,7 @@ class TwigFormatterTest extends TestCase
 
         $extensions = $formatter->getExtensions();
 
-        $this->assertSame(0, count($extensions));
+        $this->assertCount(0, $extensions);
     }
 }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataFormatterBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it is docs update.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Subject

<!-- Describe your Pull Request content here -->
Since CKEditor 4.9.0 `xhr` is default upload method. SonataMediaBundle require `form` method. Without this option CKEditor 4.9.0+ after upload show alert "Incorrect server response" error. Because in `xhr` mode it expects json response:
```
{
    "uploaded": 1,
    "fileName": "foo.jpg",
    "url": "/files/foo.jpg"
}
```
while SonataMediaBundle respond in `form` mode:
```
<script>window.parent.CKEDITOR.tools.callFunction(1, "/uploads/media/default/0001/15/3754353373720696f993c48ed28dac1287a51c86.jpeg");</script>
```
see: https://ckeditor.com/cke4/release/CKEditor-4.9.0
"1365: The File Browser plugin uses XHR requests by default."