### PR TITLE
Mark tests without assertions as such

### DIFF
--- a/tests/Form/Type/SimpleFormatterTypeTest.php
+++ b/tests/Form/Type/SimpleFormatterTypeTest.php
@@ -76,6 +76,9 @@ class SimpleFormatterTypeTest extends TestCase
         );
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testBuildForm(): void
     {
         $formBuilder = $this->createMock(FormBuilderInterface::class);


### PR DESCRIPTION
This is intentional, we want to see if the form fails to build.

I am targeting this branch, because this is pedantic. There is another warning left, but it comes from a parent test in the core bundle.