### PR TITLE
Added null check to FormatterListener

### DIFF
--- a/src/Form/EventListener/FormatterListener.php
+++ b/src/Form/EventListener/FormatterListener.php
@@ -58,7 +58,7 @@ final class FormatterListener
         // make sure the listener works with array
         $data = $event->getData();
 
-        $accessor->setValue($data, $this->targetField, $this->pool->transform($format, $source));
+        $accessor->setValue($data, $this->targetField, $source ? $this->pool->transform($format, $source) : null);
 
         $event->setData($data);
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataFormatterBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a patch.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Catch null values in FormatterListener
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->

## Subject

The `FormatterListener` was failing if you tried to transform a null value.