### PR TITLE
Removed Twig deprecations

### DIFF
--- a/src/DependencyInjection/SonataFormatterExtension.php
+++ b/src/DependencyInjection/SonataFormatterExtension.php
@@ -20,6 +20,9 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Twig\Extension\SandboxExtension;
+use Twig\Lexer;
+use Twig\Loader\ArrayLoader;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
@@ -106,7 +109,7 @@ final class SonataFormatterExtension extends Extension
 
     private function createEnvironment(ContainerBuilder $container, string $code, array $extensions): string
     {
-        $loader = new Definition('Twig_Loader_Array');
+        $loader = new Definition(ArrayLoader::class);
 
         $loader->setPublic(false);
 
@@ -131,7 +134,7 @@ final class SonataFormatterExtension extends Extension
         $sandboxPolicy->setPublic(false);
         $container->setDefinition(sprintf('sonata.formatter.twig.sandbox.%s.policy', $code), $sandboxPolicy);
 
-        $sandbox = new Definition('Twig_Extension_Sandbox', [$sandboxPolicy, true]);
+        $sandbox = new Definition(SandboxExtension::class, [$sandboxPolicy, true]);
         $sandbox->setPublic(false);
 
         $container->setDefinition(sprintf('sonata.formatter.twig.sandbox.%s', $code), $sandbox);
@@ -142,7 +145,7 @@ final class SonataFormatterExtension extends Extension
             $env->addMethodCall('addExtension', [new Reference($extension)]);
         }
 
-        $lexer = new Definition('Twig_Lexer', [new Reference(sprintf('sonata.formatter.twig.env.%s', $code)), [
+        $lexer = new Definition(Lexer::class, [new Reference(sprintf('sonata.formatter.twig.env.%s', $code)), [
             'tag_comment' => ['<#', '#>'],
             'tag_block' => ['<%', '%>'],
             'tag_variable' => ['<%=', '%>'],

--- a/tests/Form/EventListener/FormatterListenerTest.php
+++ b/tests/Form/EventListener/FormatterListenerTest.php
@@ -43,9 +43,9 @@ class FormatterListenerTest extends TestCase
     public function testWithValidFormatter(): void
     {
         $formatter = $this->createMock(FormatterInterface::class);
-        $formatter->expects($this->once())->method('transform')->will($this->returnCallback(static function ($text) {
+        $formatter->expects($this->once())->method('transform')->willReturnCallback(static function ($text) {
             return strtoupper($text);
-        }));
+        });
 
         $pool = $this->getPool();
         $pool->add('myformat', $formatter);

--- a/tests/Form/Type/FormatterTypeTest.php
+++ b/tests/Form/Type/FormatterTypeTest.php
@@ -99,11 +99,11 @@ class FormatterTypeTest extends TestCase
         $choiceFormBuilder->expects($this->once())
             ->method('getOption')
             ->with('choices')
-            ->will($this->returnValue(['foo' => 'bar']));
+            ->willReturn(['foo' => 'bar']);
 
         $formBuilder = $this->createMock(FormBuilderInterface::class);
         $formBuilder->expects($this->exactly(3))->method('add');
-        $formBuilder->expects($this->once())->method('get')->will($this->returnValue($choiceFormBuilder));
+        $formBuilder->expects($this->once())->method('get')->willReturn($choiceFormBuilder);
         $formBuilder->expects($this->once())->method('remove');
 
         $options = [
@@ -127,11 +127,11 @@ class FormatterTypeTest extends TestCase
         $choiceFormBuilder->expects($this->once())
             ->method('getOption')
             ->with('choices')
-            ->will($this->returnValue(['foo' => 'bar', 'foo2' => 'bar2']));
+            ->willReturn(['foo' => 'bar', 'foo2' => 'bar2']);
 
         $formBuilder = $this->createMock(FormBuilderInterface::class);
         $formBuilder->expects($this->exactly(2))->method('add');
-        $formBuilder->expects($this->once())->method('get')->will($this->returnValue($choiceFormBuilder));
+        $formBuilder->expects($this->once())->method('get')->willReturn($choiceFormBuilder);
 
         $options = [
             'format_field' => 'format',
@@ -160,7 +160,7 @@ class FormatterTypeTest extends TestCase
         $choiceFormBuilder->expects($this->once())
             ->method('getOption')
             ->with('choices')
-            ->will($this->returnValue($formatters));
+            ->willReturn($formatters);
 
         $options = [
             'format_field' => 'SomeFormatField',
@@ -182,7 +182,7 @@ class FormatterTypeTest extends TestCase
             'data' => $selectedFormat,
             'choices' => $formatters,
         ]);
-        $formBuilder->expects($this->at(1))->method('get')->will($this->returnValue($choiceFormBuilder));
+        $formBuilder->expects($this->at(1))->method('get')->willReturn($choiceFormBuilder);
         $formBuilder->expects($this->at(2))->method('add')->with('SomeSourceField', TextareaType::class, [
             'property_path' => 'SomeSourceField',
         ]);
@@ -202,7 +202,7 @@ class FormatterTypeTest extends TestCase
         $choiceFormBuilder->expects($this->once())
             ->method('getOption')
             ->with('choices')
-            ->will($this->returnValue($formatters));
+            ->willReturn($formatters);
 
         $formBuilder = $this->createMock(FormBuilderInterface::class);
         $formBuilder->expects($this->at(0))->method('add')->with('SomeFormatField', ChoiceType::class, [
@@ -210,7 +210,7 @@ class FormatterTypeTest extends TestCase
             'data' => $defaultFormatter = 'text',
             'choices' => $formatters,
         ]);
-        $formBuilder->expects($this->at(1))->method('get')->will($this->returnValue($choiceFormBuilder));
+        $formBuilder->expects($this->at(1))->method('get')->willReturn($choiceFormBuilder);
         $formBuilder->expects($this->at(2))->method('add')->with('SomeSourceField', TextareaType::class, [
             'property_path' => 'SomeSourceField',
         ]);
@@ -243,7 +243,7 @@ class FormatterTypeTest extends TestCase
         $choiceFormBuilder->expects($this->once())
             ->method('getOption')
             ->with('choices')
-            ->will($this->returnValue($formatters));
+            ->willReturn($formatters);
 
         $formBuilder = $this->createMock(FormBuilderInterface::class);
         $formBuilder->expects($this->at(0))->method('add')->with('SomeFormatField', ChoiceType::class, [
@@ -251,7 +251,7 @@ class FormatterTypeTest extends TestCase
             'data' => $defaultFormatter = 'text',
             'choices' => $formatters,
         ]);
-        $formBuilder->expects($this->at(1))->method('get')->will($this->returnValue($choiceFormBuilder));
+        $formBuilder->expects($this->at(1))->method('get')->willReturn($choiceFormBuilder);
         $formBuilder->expects($this->at(2))->method('add')->with('SomeSourceField', TextareaType::class, [
             'property_path' => 'SomeSourceField',
         ]);
@@ -277,15 +277,15 @@ class FormatterTypeTest extends TestCase
     {
         $defaultConfig = 'default';
         $defaultConfigValues = ['toolbar' => ['Button1']];
-        $this->configManager->expects($this->once())->method('getDefaultConfig')->will($this->returnValue($defaultConfig));
+        $this->configManager->expects($this->once())->method('getDefaultConfig')->willReturn($defaultConfig);
         $this->configManager->expects($this->once())
             ->method('hasConfig')
             ->with($defaultConfig)
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $this->configManager->expects($this->once())
             ->method('getConfig')
             ->with($defaultConfig)
-            ->will($this->returnValue($defaultConfigValues));
+            ->willReturn($defaultConfigValues);
 
         /** @var \Symfony\Component\Form\FormView $view */
         $view = $this->createMock(FormView::class);
@@ -310,11 +310,11 @@ class FormatterTypeTest extends TestCase
     public function testBuildViewWithoutDefaultConfig(): void
     {
         $defaultConfig = 'default';
-        $this->configManager->expects($this->once())->method('getDefaultConfig')->will($this->returnValue($defaultConfig));
+        $this->configManager->expects($this->once())->method('getDefaultConfig')->willReturn($defaultConfig);
         $this->configManager->expects($this->once())
             ->method('hasConfig')
             ->with($defaultConfig)
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $ckEditorToolBarIcons = ['Icon 1'];
 
@@ -343,15 +343,15 @@ class FormatterTypeTest extends TestCase
     {
         $defaultConfig = 'default';
         $defaultConfigValues = ['toolbar' => ['Button 1']];
-        $this->configManager->expects($this->once())->method('getDefaultConfig')->will($this->returnValue($defaultConfig));
+        $this->configManager->expects($this->once())->method('getDefaultConfig')->willReturn($defaultConfig);
         $this->configManager->expects($this->once())
             ->method('hasConfig')
             ->with($defaultConfig)
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $this->configManager->expects($this->once())
             ->method('getConfig')
             ->with($defaultConfig)
-            ->will($this->returnValue($defaultConfigValues));
+            ->willReturn($defaultConfigValues);
 
         $ckEditorToolBarIcons = ['Icon 1'];
 
@@ -412,15 +412,15 @@ class FormatterTypeTest extends TestCase
     {
         $defaultConfig = 'default';
         $defaultConfigValues = ['toolbar' => ['Button1']];
-        $this->configManager->expects($this->once())->method('getDefaultConfig')->will($this->returnValue($defaultConfig));
+        $this->configManager->expects($this->once())->method('getDefaultConfig')->willReturn($defaultConfig);
         $this->configManager->expects($this->once())
             ->method('hasConfig')
             ->with($defaultConfig)
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $this->configManager->expects($this->once())
             ->method('getConfig')
             ->with($defaultConfig)
-            ->will($this->returnValue($defaultConfigValues));
+            ->willReturn($defaultConfigValues);
 
         /** @var FormView $view */
         $view = $this->createMock(FormView::class);
@@ -448,19 +448,19 @@ class FormatterTypeTest extends TestCase
         $toolbar_config = 'custom_toolbar';
         $defaultConfigValues = ['toolbar' => $toolbar_config];
         $custom_toolbar = ['Button 1'];
-        $this->configManager->expects($this->once())->method('getDefaultConfig')->will($this->returnValue($defaultConfig));
+        $this->configManager->expects($this->once())->method('getDefaultConfig')->willReturn($defaultConfig);
         $this->configManager->expects($this->once())
             ->method('hasConfig')
             ->with($defaultConfig)
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $this->configManager->expects($this->once())
             ->method('getConfig')
             ->with($defaultConfig)
-            ->will($this->returnValue($defaultConfigValues));
+            ->willReturn($defaultConfigValues);
         $this->toolbarManager->expects($this->once())
             ->method('resolveToolbar')
             ->with($toolbar_config)
-            ->will($this->returnValue($custom_toolbar));
+            ->willReturn($custom_toolbar);
 
         /** @var FormView $view */
         $view = $this->createMock(FormView::class);
@@ -486,15 +486,15 @@ class FormatterTypeTest extends TestCase
     {
         $defaultConfig = 'default';
         $defaultConfigValues = ['toolbar' => ['Button1']];
-        $this->configManager->expects($this->once())->method('getDefaultConfig')->will($this->returnValue($defaultConfig));
+        $this->configManager->expects($this->once())->method('getDefaultConfig')->willReturn($defaultConfig);
         $this->configManager->expects($this->once())
             ->method('hasConfig')
             ->with($defaultConfig)
-            ->will($this->returnValue(true));
+            ->willReturn(true);
         $this->configManager->expects($this->once())
             ->method('getConfig')
             ->with($defaultConfig)
-            ->will($this->returnValue($defaultConfigValues));
+            ->willReturn($defaultConfigValues);
 
         $templates = [
             'imagesPath' => '/bundles/mybundle/templates/images',
@@ -508,8 +508,8 @@ class FormatterTypeTest extends TestCase
             ],
         ];
 
-        $this->templateManager->expects($this->once())->method('hasTemplates')->will($this->returnValue(true));
-        $this->templateManager->expects($this->once())->method('getTemplates')->will($this->returnValue($templates));
+        $this->templateManager->expects($this->once())->method('hasTemplates')->willReturn(true);
+        $this->templateManager->expects($this->once())->method('getTemplates')->willReturn($templates);
 
         /** @var FormView $view */
         $view = $this->createMock(FormView::class);

--- a/tests/Form/Type/SimpleFormatterTypeTest.php
+++ b/tests/Form/Type/SimpleFormatterTypeTest.php
@@ -96,7 +96,7 @@ class SimpleFormatterTypeTest extends TestCase
         $this->configManager->expects($this->once())
             ->method('getConfig')
             ->with('context')
-            ->will($this->returnValue(['toolbar' => ['Button1']]));
+            ->willReturn(['toolbar' => ['Button1']]);
         $view->vars['id'] = 'SomeId';
         $view->vars['name'] = 'SomeName';
 
@@ -142,13 +142,13 @@ class SimpleFormatterTypeTest extends TestCase
         $this->configManager->expects($this->once())
             ->method('getConfig')
             ->with('context')
-            ->will($this->returnValue(['toolbar' => ['Button1']]));
+            ->willReturn(['toolbar' => ['Button1']]);
         $this->stylesSetManager->expects($this->once())
             ->method('getStylesSets')
-            ->will($this->returnValue($styleSets));
+            ->willReturn($styleSets);
         $this->stylesSetManager->expects($this->once())
             ->method('hasStylesSets')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $view->vars['id'] = 'SomeId';
         $view->vars['name'] = 'SomeName';

--- a/tests/Formatter/MarkdownFormatterTest.php
+++ b/tests/Formatter/MarkdownFormatterTest.php
@@ -22,7 +22,7 @@ class MarkdownFormatterTest extends TestCase
     public function testFormatter(): void
     {
         $parser = $this->createMock(MarkdownParserInterface::class);
-        $parser->expects($this->any())->method('transformMarkdown')->will($this->returnValue('<b>Salut</b>'));
+        $parser->expects($this->any())->method('transformMarkdown')->willReturn('<b>Salut</b>');
         $formatter = new MarkdownFormatter($parser);
 
         $this->assertSame('<b>Salut</b>', $formatter->transform('*Salut*'));

--- a/tests/Formatter/PoolTest.php
+++ b/tests/Formatter/PoolTest.php
@@ -30,9 +30,9 @@ class PoolTest extends TestCase
         $env = $this->createMock(Environment::class);
         $template = $this->createMock(Template::class);
 
-        $template->expects($this->once())->method('render')->will($this->returnValue('Salut'));
+        $template->expects($this->once())->method('render')->willReturn('Salut');
 
-        $env->expects($this->once())->method('createTemplate')->will($this->returnValue($template));
+        $env->expects($this->once())->method('createTemplate')->willReturn($template);
 
         $pool = $this->getPool();
 
@@ -63,7 +63,7 @@ class PoolTest extends TestCase
             ->method('render')
             ->will($this->throwException(new SyntaxError('Error')));
 
-        $env->expects($this->once())->method('createTemplate')->will($this->returnValue($template));
+        $env->expects($this->once())->method('createTemplate')->willReturn($template);
 
         $pool = $this->getPool();
         $pool->add('foo', $formatter, $env);
@@ -81,7 +81,7 @@ class PoolTest extends TestCase
             ->method('render')
             ->will($this->throwException(new SecurityError('Error')));
 
-        $env->expects($this->once())->method('createTemplate')->will($this->returnValue($template));
+        $env->expects($this->once())->method('createTemplate')->willReturn($template);
 
         $pool = $this->getPool();
         $pool->add('foo', $formatter, $env);
@@ -101,7 +101,7 @@ class PoolTest extends TestCase
             ->method('render')
             ->will($this->throwException(new \RuntimeException('Error')));
 
-        $env->expects($this->once())->method('createTemplate')->will($this->returnValue($template));
+        $env->expects($this->once())->method('createTemplate')->willReturn($template);
 
         $pool = $this->getPool();
         $pool->add('foo', $formatter, $env);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I removed a few Twig deprecations in the `SonataFormatterExtension` class.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataFormatterBundle/blob/4.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it is backward compatible.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #407

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataFormatterBundle/releases,
    please keep it short and clear and to the point
-->

# Changelog

```markdown
### Changed
- Removed Twig deprecations
```

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->

A lot of other deprecations remain but they are from the CKEditor bundle.
