### PR TITLE
Fix ignoring fos_ck_editor.configs.toolbar param in config.yml

### DIFF
--- a/src/Form/Type/SimpleFormatterType.php
+++ b/src/Form/Type/SimpleFormatterType.php
@@ -67,9 +67,17 @@ final class SimpleFormatterType extends AbstractType
 
     public function buildView(FormView $view, FormInterface $form, array $options): void
     {
-        $ckeditorConfiguration = [
-            'toolbar' => array_values($options['ckeditor_toolbar_icons']),
-        ];
+
+        $defaultConfig = $this->configManager->getDefaultConfig();
+        if ($this->configManager->hasConfig($defaultConfig)) {
+            $ckeditorConfiguration = $this->configManager->getConfig($defaultConfig);
+        } else {
+            $ckeditorConfiguration = [];
+        }
+
+        if (!\array_key_exists('toolbar', $ckeditorConfiguration)) {
+            $ckeditorConfiguration['toolbar'] = array_values($options['ckeditor_toolbar_icons']);
+        }
 
         if ($options['ckeditor_context']) {
             $contextConfig = $this->configManager->getConfig($options['ckeditor_context']);

--- a/src/Form/Type/SimpleFormatterType.php
+++ b/src/Form/Type/SimpleFormatterType.php
@@ -67,7 +67,6 @@ final class SimpleFormatterType extends AbstractType
 
     public function buildView(FormView $view, FormInterface $form, array $options): void
     {
-
         $defaultConfig = $this->configManager->getDefaultConfig();
         if ($this->configManager->hasConfig($defaultConfig)) {
             $ckeditorConfiguration = $this->configManager->getConfig($defaultConfig);

--- a/tests/Form/Type/SimpleFormatterTypeTest.php
+++ b/tests/Form/Type/SimpleFormatterTypeTest.php
@@ -166,4 +166,56 @@ class SimpleFormatterTypeTest extends TestCase
 
         $this->assertSame($view->vars['ckeditor_style_sets'], $styleSets);
     }
+    public function testBuildViewWithToolbarOptionsSetAsPredefinedString(): void
+    {
+        $defaultConfig = 'default';
+        $defaultConfigValues = ['toolbar' => 'basic'];
+        $basicToolbarSets = [
+            0 =>
+                [
+                    0 => 'Bold',
+                    1 => 'Italic',
+                ],
+            1 =>
+                [
+                    0 => 'NumberedList',
+                    1 => 'BulletedList',
+
+                ],
+        ];
+
+        $this->configManager->expects($this->once())->method('getDefaultConfig')->willReturn($defaultConfig);
+        $this->configManager->expects($this->once())
+            ->method('hasConfig')
+            ->with($defaultConfig)
+            ->willReturn(true);
+        $this->configManager->expects($this->once())
+            ->method('getConfig')
+            ->with($defaultConfig)
+            ->willReturn($defaultConfigValues);
+        $this->toolbarManager->expects($this->once())
+            ->method('resolveToolbar')
+            ->with('basic')
+            ->willReturn($basicToolbarSets);
+
+
+        /** @var \Symfony\Component\Form\FormView $view */
+        $view = $this->createMock(FormView::class);
+        $form = $this->createMock(FormInterface::class);
+        $this->formType->buildView($view, $form, [
+            'source_field' => 'SomeField',
+            'format_field' => 'SomeFormat',
+            'format_field_options' => 'SomeOptions',
+            'ckeditor_context' => null,
+            'ckeditor_image_format' => null,
+            'ckeditor_basepath' => '',
+            'ckeditor_plugins' => [],
+            'ckeditor_templates' => [],
+            'ckeditor_toolbar_icons' => [],
+            'format' => [],
+        ]);
+
+        $defaultConfigValues['toolbar'] = $basicToolbarSets;
+        $this->assertSame($view->vars['ckeditor_configuration'], $defaultConfigValues);
+    }
 }

--- a/tests/Form/Type/SimpleFormatterTypeTest.php
+++ b/tests/Form/Type/SimpleFormatterTypeTest.php
@@ -166,18 +166,17 @@ class SimpleFormatterTypeTest extends TestCase
 
         $this->assertSame($view->vars['ckeditor_style_sets'], $styleSets);
     }
+
     public function testBuildViewWithToolbarOptionsSetAsPredefinedString(): void
     {
         $defaultConfig = 'default';
         $defaultConfigValues = ['toolbar' => 'basic'];
         $basicToolbarSets = [
-            0 =>
-                [
+            0 => [
                     0 => 'Bold',
                     1 => 'Italic',
                 ],
-            1 =>
-                [
+            1 => [
                     0 => 'NumberedList',
                     1 => 'BulletedList',
 
@@ -197,7 +196,6 @@ class SimpleFormatterTypeTest extends TestCase
             ->method('resolveToolbar')
             ->with('basic')
             ->willReturn($basicToolbarSets);
-
 
         /** @var \Symfony\Component\Form\FormView $view */
         $view = $this->createMock(FormView::class);


### PR DESCRIPTION
## Subject

Fix ignoring fos_ck_editor.configs.toolbar param in application config when using SimpleFormatterType.

I am targeting this branch, because setting up toolbar type in main config is important for easy using SimpleFormatterType.
Set up toolbar as full, standard or basic was overriden by $options['ckeditor_toolbar_icons']


## Changelog

```markdown
- Fix posibility to easily switch the toolbar configuration by using the full, standard or basic keyword as toolbar with SimpleFormatterType
```
