### PR TITLE
Add new interface for extendable formatters

### DIFF
--- a/src/DependencyInjection/SonataFormatterExtension.php
+++ b/src/DependencyInjection/SonataFormatterExtension.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\FormatterBundle\DependencyInjection;
 
+use Sonata\FormatterBundle\Formatter\ExtendableFormatter;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -139,10 +140,12 @@ final class SonataFormatterExtension extends Extension
 
         $container->setDefinition(sprintf('sonata.formatter.twig.sandbox.%s', $code), $sandbox);
 
-        $env->addMethodCall('addExtension', [new Reference(sprintf('sonata.formatter.twig.sandbox.%s', $code))]);
+        if (is_a($env->getClass(), ExtendableFormatter::class)) {
+            $env->addMethodCall('addExtension', [new Reference(sprintf('sonata.formatter.twig.sandbox.%s', $code))]);
 
-        foreach ($extensions as $extension) {
-            $env->addMethodCall('addExtension', [new Reference($extension)]);
+            foreach ($extensions as $extension) {
+                $env->addMethodCall('addExtension', [new Reference($extension)]);
+            }
         }
 
         $lexer = new Definition(Lexer::class, [new Reference(sprintf('sonata.formatter.twig.env.%s', $code)), [

--- a/src/Formatter/ExtendableFormatter.php
+++ b/src/Formatter/ExtendableFormatter.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\FormatterBundle\Formatter;
+
+use Sonata\FormatterBundle\Extension\ExtensionInterface;
+
+interface ExtendableFormatter extends Formatter
+{
+    public function addExtension(ExtensionInterface $extension);
+
+    /**
+     * @return ExtensionInterface[]
+     */
+    public function getExtensions(): array;
+}

--- a/src/Formatter/Formatter.php
+++ b/src/Formatter/Formatter.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\FormatterBundle\Formatter;
+
+interface Formatter
+{
+    /**
+     * @return string
+     */
+    public function transform(string $text);
+}

--- a/src/Formatter/FormatterInterface.php
+++ b/src/Formatter/FormatterInterface.php
@@ -13,16 +13,15 @@ declare(strict_types=1);
 
 namespace Sonata\FormatterBundle\Formatter;
 
-use Sonata\FormatterBundle\Extension\ExtensionInterface;
+@trigger_error(
+    'The '.__NAMESPACE__.'\FormatterInterface interface is deprecated since sonata-project/formatter-bundle 4.x, to be removed in 5.0. '.
+    'Use Formatter or ExtendableFormatter instead.',
+    E_USER_DEPRECATED
+);
 
-interface FormatterInterface
+/**
+ * @deprecated since sonata-project/formatter-bundle 4.x, to be removed in 5.0.
+ */
+interface FormatterInterface extends ExtendableFormatter
 {
-    public function transform(string $text);
-
-    public function addExtension(ExtensionInterface $extensionInterface);
-
-    /**
-     * @return ExtensionInterface[]
-     */
-    public function getExtensions(): array;
 }

--- a/tests/Form/EventListener/FormatterListenerTest.php
+++ b/tests/Form/EventListener/FormatterListenerTest.php
@@ -40,6 +40,11 @@ class FormatterListenerTest extends TestCase
         $listener->postSubmit($event);
     }
 
+    /**
+     * NEXT_MAJOR: Remove the group when deleting FormatterInterface.
+     *
+     * @group legacy
+     */
     public function testWithValidFormatter(): void
     {
         $formatter = $this->createMock(FormatterInterface::class);

--- a/tests/Formatter/MarkdownFormatterTest.php
+++ b/tests/Formatter/MarkdownFormatterTest.php
@@ -19,6 +19,11 @@ use Sonata\FormatterBundle\Formatter\MarkdownFormatter;
 
 class MarkdownFormatterTest extends TestCase
 {
+    /**
+     * NEXT_MAJOR: Remove the group when deleting FormatterInterface.
+     *
+     * @group legacy
+     */
     public function testFormatter(): void
     {
         $parser = $this->createMock(MarkdownParserInterface::class);

--- a/tests/Formatter/RawFormatterTest.php
+++ b/tests/Formatter/RawFormatterTest.php
@@ -18,6 +18,11 @@ use Sonata\FormatterBundle\Formatter\RawFormatter;
 
 class RawFormatterTest extends TestCase
 {
+    /**
+     * NEXT_MAJOR: Remove the group when deleting FormatterInterface.
+     *
+     * @group legacy
+     */
     public function testFormatter(): void
     {
         $formatter = new RawFormatter();

--- a/tests/Formatter/TextFormatterTest.php
+++ b/tests/Formatter/TextFormatterTest.php
@@ -18,6 +18,11 @@ use Sonata\FormatterBundle\Formatter\TextFormatter;
 
 class TextFormatterTest extends TestCase
 {
+    /**
+     * NEXT_MAJOR: Remove the group when deleting FormatterInterface.
+     *
+     * @group legacy
+     */
     public function testFormatter(): void
     {
         $formatter = new TextFormatter();

--- a/tests/Formatter/TwigFormatterTest.php
+++ b/tests/Formatter/TwigFormatterTest.php
@@ -18,6 +18,11 @@ use Sonata\FormatterBundle\Formatter\TwigFormatter;
 
 class TwigFormatterTest extends TestCase
 {
+    /**
+     * NEXT_MAJOR: Remove the group when deleting FormatterInterface.
+     *
+     * @group legacy
+     */
     public function testFormatter(): void
     {
         $loader = new MyStringLoader();

--- a/tests/Validator/Constraints/FormatterValidatorTest.php
+++ b/tests/Validator/Constraints/FormatterValidatorTest.php
@@ -70,6 +70,11 @@ class FormatterValidatorTest extends TestCase
         $validator->validate('existingFormatter', $this->constraint);
     }
 
+    /**
+     * NEXT_MAJOR: Remove the group when deleting FormatterInterface.
+     *
+     * @group legacy
+     */
     public function testValidCase(): void
     {
         $this->pool->add('existingFormatter', $this->createMock(FormatterInterface::class));


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Some formatters do not support extensions (e.g. https://github.com/sonata-project/SonataFormatterBundle/blob/4.x/src/Formatter/TwigFormatter.php#L56), so we should split the existing interface

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataFormatterBundle/blob/4.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataFormatterBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added new `Formatter` interface
- Added new `ExtendableFormatter` interface
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
