### PR TITLE
Drop support for symfony <4.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,29 +23,30 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
         "friendsofsymfony/ckeditor-bundle": "^1.0",
         "knplabs/knp-markdown-bundle": "^1.7",
         "psr/log": "^1.0",
         "sonata-project/block-bundle": "^3.16.1",
         "sonata-project/form-extensions": "^0.1 || ^1.4",
-        "symfony/config": "^3.4 || ^4.0",
-        "symfony/dependency-injection": "^3.4.26 || ^4.1.12",
-        "symfony/event-dispatcher": "^3.2 || ^4.0",
-        "symfony/form": "^3.4 || ^4.0",
-        "symfony/framework-bundle": "^3.4.26 || ^4.1.12",
-        "symfony/http-foundation": "^3.4.35 || ^4.2.12",
-        "symfony/http-kernel": "^3.4 || ^4.0",
-        "symfony/options-resolver": "^3.4 || ^4.0",
-        "symfony/property-access": "^3.4 || ^4.0",
-        "symfony/translation": "^3.4 || ^4.0",
-        "symfony/twig-bridge": "^3.4 || ^4.0",
-        "symfony/validator": "^3.4 || ^4.0",
-        "twig/twig": "^2.4"
+        "symfony/config": "^4.3",
+        "symfony/dependency-injection": "^4.3",
+        "symfony/event-dispatcher": "^4.3",
+        "symfony/form": "^4.3",
+        "symfony/framework-bundle": "^4.3",
+        "symfony/http-foundation": "^4.3",
+        "symfony/http-kernel": "^4.3",
+        "symfony/options-resolver": "^4.3",
+        "symfony/property-access": "^4.3",
+        "symfony/translation": "^4.3",
+        "symfony/twig-bridge": "^4.3",
+        "symfony/validator": "^4.3",
+        "twig/twig": "^2.12.1"
     },
     "conflict": {
         "sonata-project/admin-bundle": "<3.27",
-        "sonata-project/media-bundle": "<3.0"
+        "sonata-project/core-bundle": "<3.20",
+        "sonata-project/media-bundle": "<3.20"
     },
     "require-dev": {
         "matthiasnoback/symfony-dependency-injection-test": "^4.0",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
This change will allow install optionally only CoreBundle v3.20 (which constains all deprecations notes).

#### Remove process will be look like:
- update CoreBundle to 3.20
- remove deprecations
- remove CoreBundle
- upgrade extensions to 1.x

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCommentBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

I am targeting this branch, because this change respect BC.

## Changelog
```markdown
### Removed
Support for Symfony < 4.3
```