### PR TITLE
Allow some symfony/* dependencies to use version ^5.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,8 +36,8 @@
         "symfony/framework-bundle": "^4.4",
         "symfony/http-foundation": "^4.4",
         "symfony/http-kernel": "^4.4",
-        "symfony/options-resolver": "^4.4",
-        "symfony/property-access": "^4.4",
+        "symfony/options-resolver": "^4.4 || ^5.1",
+        "symfony/property-access": "^4.4 || ^5.1",
         "symfony/translation": "^4.4",
         "symfony/twig-bridge": "^4.4",
         "symfony/validator": "^4.4",
@@ -52,7 +52,7 @@
         "matthiasnoback/symfony-dependency-injection-test": "^4.1",
         "sonata-project/admin-bundle": "^3.31",
         "sonata-project/media-bundle": "^3.10",
-        "symfony/phpunit-bridge": "^5.1"
+        "symfony/phpunit-bridge": "^5.1.1"
     },
     "suggest": {
         "sonata-project/admin-bundle": "For using the admin media browser.",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Allow some symfony/* dependencies to use version ^5.1, since these major versions don't have breaking changes. See:
* https://github.com/symfony/options-resolver/blob/v5.0.0/CHANGELOG.md#500;
* https://github.com/symfony/property-access/blob/v5.0.0/CHANGELOG.md.

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Depends on sonata-project/SonataAdminBundle#6299, sonata-project/SonataMediaBundle#1786.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added support for symfony/options-resolver:^5.1;
- Added support for symfony/property-access:^5.1.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
