### PR TITLE
Use ProphecyTrait to fix warnings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,6 +50,7 @@
     },
     "require-dev": {
         "matthiasnoback/symfony-dependency-injection-test": "^4.1",
+        "phpspec/prophecy-phpunit": "^2.0",
         "sonata-project/admin-bundle": "^3.31",
         "sonata-project/media-bundle": "^3.10",
         "symfony/phpunit-bridge": "^5.1"

--- a/tests/Controller/CkeditorAdminControllerTest.php
+++ b/tests/Controller/CkeditorAdminControllerTest.php
@@ -15,6 +15,7 @@ namespace Sonata\FormatterBundle\Tests\Controller;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Sonata\AdminBundle\Admin\Pool as AdminPool;
 use Sonata\AdminBundle\Datagrid\DatagridInterface;
 use Sonata\AdminBundle\Templating\TemplateRegistry;
@@ -48,6 +49,8 @@ class EntityWithGetId
 
 class CkeditorAdminControllerTest extends TestCase
 {
+    use ProphecyTrait;
+
     private $container;
     private $admin;
     private $request;

--- a/tests/Twig/Loader/LoaderSelectorTest.php
+++ b/tests/Twig/Loader/LoaderSelectorTest.php
@@ -14,11 +14,14 @@ declare(strict_types=1);
 namespace Sonata\FormatterBundle\Tests\Twig\Loader;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Sonata\FormatterBundle\Twig\Loader\LoaderSelector;
 use Twig\Loader\LoaderInterface;
 
 class LoaderSelectorTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testCanBeInstanciated(): void
     {
         $loaderSelector = new LoaderSelector(


### PR DESCRIPTION
The PHP 8 test was failing because it throws warnings about Prophecy integration being deprecated in PHPunit 9.
I added `phpspec/prophecy-phpunit` to use `ProphecyTrait`. I guess the same should be done in SonataAdminBundle.
