### PR TITLE
Add support for symfony/validator ^5.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "symfony/property-access": "^4.4 || ^5.1",
         "symfony/translation": "^4.4",
         "symfony/twig-bridge": "^4.4",
-        "symfony/validator": "^4.4",
+        "symfony/validator": "^4.4 || ^5.1",
         "twig/twig": "^2.12.1"
     },
     "conflict": {

--- a/tests/Validator/Constraints/FormatterValidatorTest.php
+++ b/tests/Validator/Constraints/FormatterValidatorTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\FormatterBundle\Tests\Validator\Constraints;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sonata\FormatterBundle\Formatter\FormatterInterface;
 use Sonata\FormatterBundle\Formatter\Pool;
@@ -24,7 +25,7 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
 class FormatterValidatorTest extends TestCase
 {
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var ExecutionContextInterface|MockObject
      */
     private $context;
 


### PR DESCRIPTION
## Subject

This update seems to have no side effects.
I also found an outdated docblock in FormatterValidatorTest.php.

I am targeting this branch, because it is backwards compatible.

## Changelog

```markdown
### Added
- Added support for `symfony/validator` ^5.1.
```