### PR TITLE
Fix Drag'n'Drop Upload : Handle JSON Response

### DIFF
--- a/src/Controller/CkeditorAdminController.php
+++ b/src/Controller/CkeditorAdminController.php
@@ -17,6 +17,7 @@ use Sonata\MediaBundle\Controller\MediaAdminController;
 use Sonata\MediaBundle\Provider\MediaProviderInterface;
 use Symfony\Component\Form\FormRenderer;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -118,6 +119,15 @@ final class CkeditorAdminController extends MediaAdminController
             $media,
             $request->get('format', MediaProviderInterface::FORMAT_REFERENCE)
         );
+
+        // handle specific json response (drag-n-drop Upload)
+        if ('json' === $request->get('responseType')) {
+            return new JsonResponse([
+                'uploaded' => 1,
+                'fileName' => $media->getName(),
+                'url' => $pool->getProvider($provider)->generatePublicUrl($media, $format),
+            ]);
+        }
 
         return $this->renderWithExtraParams($this->getTemplate('upload'), [
             'action' => 'list',


### PR DESCRIPTION
## Subject

Drag'n'drop upload is not working with CKEditor
Because in this case, CKEditor is expecting a json response.

<img width="896" alt="Capture d’écran 2021-01-15 à 18 38 15" src="https://user-images.githubusercontent.com/4090813/104762200-3d328800-5764-11eb-9935-c7d18ea56d80.png">

**Now working with this PR :**

<img width="894" alt="Capture d’écran 2021-01-15 à 18 38 04" src="https://user-images.githubusercontent.com/4090813/104762215-40c60f00-5764-11eb-9b22-fc2cb1d61d5f.png">

### Changed

Changed CkeditorAdminController.php for handling json response.