### PR TITLE
Remove legacy tests

### DIFF
--- a/tests/DependencyInjection/SonataFormatterExtensionTest.php
+++ b/tests/DependencyInjection/SonataFormatterExtensionTest.php
@@ -87,28 +87,6 @@ class SonataFormatterExtensionTest extends AbstractExtensionTestCase
         );
     }
 
-    /**
-     * @group legacy
-     */
-    public function testLoadWithoutDefaultFormatter(): void
-    {
-        $this->setParameter('kernel.bundles', []);
-        $this->load([
-            'formatters' => ['text' => [
-                'service' => 'sonata.formatter.text.text',
-                'extensions' => [
-                    'sonata.formatter.twig.control_flow',
-                    'sonata.formatter.twig.gist',
-                ],
-            ]],
-        ]);
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
-            'sonata.formatter.pool',
-            0,
-            'text'
-        );
-    }
-
     protected function getContainerExtensions(): array
     {
         return [

--- a/tests/Validator/Constraints/FormatterValidatorTest.php
+++ b/tests/Validator/Constraints/FormatterValidatorTest.php
@@ -51,9 +51,6 @@ class FormatterValidatorTest extends TestCase
         static::assertInstanceOf(ConstraintValidator::class, $validator);
     }
 
-    /**
-     * @group legacy
-     */
     public function testInvalidCase(): void
     {
         $this->constraint->message = $message = 'Constraint message';


### PR DESCRIPTION
## Subject

This PR removes the `@group legacy` annotation from all tests. One test is not necessary, as the deprecation it tests has been removed a long time ago. One test does not seem to be testing deprecated code at all.

Also see #641.