### PR TITLE
Add media extension for formatter

### DIFF
--- a/src/DependencyInjection/Compiler/AddTwigExtensionsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddTwigExtensionsCompilerPass.php
@@ -57,6 +57,8 @@ final class AddTwigExtensionsCompilerPass implements CompilerPassInterface
         Definition $env,
         array $extensions
     ): void {
+        $runtimes = [];
+
         foreach ($extensions as $extension) {
             $extensionDefinition = $container->getDefinition($extension);
             $extensionClass = $extensionDefinition->getClass();

--- a/src/DependencyInjection/Compiler/AddTwigExtensionsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddTwigExtensionsCompilerPass.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\FormatterBundle\DependencyInjection\Compiler;
+
+use Sonata\FormatterBundle\Extension\ExtensionInterface;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+use Twig\RuntimeLoader\ContainerRuntimeLoader;
+
+/**
+ * @internal
+ *
+ * @author Jordi Sala <jordism91@gmail.com>
+ */
+final class AddTwigExtensionsCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasParameter('sonata.formatter.configuration.formatters')) {
+            return;
+        }
+
+        $formatters = $container->getParameter('sonata.formatter.configuration.formatters');
+        \assert(\is_array($formatters));
+
+        foreach ($formatters as $code => $formatterConfig) {
+            if (0 !== \count($formatterConfig['extensions'])) {
+                $env = $container->getDefinition(sprintf('sonata.formatter.twig.env.%s', $code));
+
+                $this->addExtensions($container, $code, $env, $formatterConfig['extensions']);
+
+                $container->setDefinition(sprintf('sonata.formatter.twig.env.%s', $code), $env);
+            }
+        }
+    }
+
+    /**
+     * @param string[] $extensions
+     */
+    private function addExtensions(
+        ContainerBuilder $container,
+        string $code,
+        Definition $env,
+        array $extensions
+    ): void {
+        foreach ($extensions as $extension) {
+            $extensionDefinition = $container->getDefinition($extension);
+            $extensionClass = $extensionDefinition->getClass();
+
+            if (null === $extensionClass || !is_a($extensionClass, ExtensionInterface::class, true)) {
+                throw new \InvalidArgumentException(sprintf(
+                    'Extension "%s" added to formatter "%s" do not implement %s interface.',
+                    $extension,
+                    $code,
+                    ExtensionInterface::class
+                ));
+            }
+
+            $env->addMethodCall('addExtension', [new Reference($extension)]);
+
+            $extensionRuntimes = $extensionClass::getAllowedRuntimes();
+
+            foreach ($extensionRuntimes as $extensionRuntime) {
+                $runtimeDefinition = $container->getDefinition($extensionRuntime);
+                $runtimeClass = $runtimeDefinition->getClass();
+
+                if (null !== $runtimeClass) {
+                    $runtimes[$runtimeClass] = new Reference($extensionRuntime);
+                }
+            }
+        }
+
+        if ([] !== $runtimes) {
+            $runtimeLoader = new Definition(ContainerRuntimeLoader::class, [
+                ServiceLocatorTagPass::register($container, $runtimes),
+            ]);
+
+            $container->setDefinition(sprintf('sonata.formatter.twig.runtime_loader.%s', $code), $runtimeLoader);
+
+            $env->addMethodCall('addRuntimeLoader', [new Reference(sprintf('sonata.formatter.twig.runtime_loader.%s', $code))]);
+        }
+    }
+}

--- a/src/DependencyInjection/Compiler/AddTwigLexerCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddTwigLexerCompilerPass.php
@@ -36,21 +36,20 @@ final class AddTwigLexerCompilerPass implements CompilerPassInterface
         \assert(\is_array($formatters));
 
         foreach ($formatters as $code => $formatterConfig) {
-            if (0 !== \count($formatterConfig['extensions'])) {
-                $env = $container->getDefinition(sprintf('sonata.formatter.twig.env.%s', $code));
+            $envId = sprintf('sonata.formatter.twig.env.%s', $code);
 
-                $lexer = new Definition(Lexer::class, [new Reference(sprintf('sonata.formatter.twig.env.%s', $code)), [
-                    'tag_comment' => ['<#', '#>'],
-                    'tag_block' => ['<%', '%>'],
-                    'tag_variable' => ['<%=', '%>'],
-                ]]);
-                $lexer->setPublic(false);
-
-                $container->setDefinition(sprintf('sonata.formatter.twig.lexer.%s', $code), $lexer);
-
-                $env->addMethodCall('setLexer', [new Reference(sprintf('sonata.formatter.twig.lexer.%s', $code))]);
-
-                $container->setDefinition(sprintf('sonata.formatter.twig.env.%s', $code), $env);
+            if ($container->hasDefinition($envId)) {
+                $container->getDefinition($envId)
+                    ->addMethodCall('setLexer', [
+                        new Definition(Lexer::class, [
+                            new Reference($envId),
+                            [
+                                'tag_comment' => ['<#', '#>'],
+                                'tag_block' => ['<%', '%>'],
+                                'tag_variable' => ['<%=', '%>'],
+                            ],
+                        ]),
+                    ]);
             }
         }
     }

--- a/src/DependencyInjection/Compiler/AddTwigLexerCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddTwigLexerCompilerPass.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\FormatterBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+use Twig\Lexer;
+
+/**
+ * @internal
+ *
+ * @author Jordi Sala <jordism91@gmail.com>
+ */
+final class AddTwigLexerCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasParameter('sonata.formatter.configuration.formatters')) {
+            return;
+        }
+
+        $formatters = $container->getParameter('sonata.formatter.configuration.formatters');
+        \assert(\is_array($formatters));
+
+        foreach ($formatters as $code => $formatterConfig) {
+            if (0 !== \count($formatterConfig['extensions'])) {
+                $env = $container->getDefinition(sprintf('sonata.formatter.twig.env.%s', $code));
+
+                $lexer = new Definition(Lexer::class, [new Reference(sprintf('sonata.formatter.twig.env.%s', $code)), [
+                    'tag_comment' => ['<#', '#>'],
+                    'tag_block' => ['<%', '%>'],
+                    'tag_variable' => ['<%=', '%>'],
+                ]]);
+                $lexer->setPublic(false);
+
+                $container->setDefinition(sprintf('sonata.formatter.twig.lexer.%s', $code), $lexer);
+
+                $env->addMethodCall('setLexer', [new Reference(sprintf('sonata.formatter.twig.lexer.%s', $code))]);
+
+                $container->setDefinition(sprintf('sonata.formatter.twig.env.%s', $code), $env);
+            }
+        }
+    }
+}

--- a/src/DependencyInjection/SonataFormatterExtension.php
+++ b/src/DependencyInjection/SonataFormatterExtension.php
@@ -173,8 +173,13 @@ final class SonataFormatterExtension extends Extension
 
             $extensionRuntimes = $extensionClass::getAllowedRuntimes();
 
-            foreach ($extensionRuntimes as $extensionRuntimeId => $extensionRuntimeClass) {
-                $runtimes[$extensionRuntimeClass] = new Reference($extensionRuntimeId);
+            foreach ($extensionRuntimes as $extensionRuntime) {
+                $runtimeDefinition = $container->getDefinition($extensionRuntime);
+                $runtimeClass = $runtimeDefinition->getClass();
+
+                if (null !== $runtimeClass) {
+                    $runtimes[$runtimeClass] = new Reference($extensionRuntime);
+                }
             }
         }
 

--- a/src/DependencyInjection/SonataFormatterExtension.php
+++ b/src/DependencyInjection/SonataFormatterExtension.php
@@ -101,19 +101,9 @@ final class SonataFormatterExtension extends Extension
         );
     }
 
-    public function getXsdValidationBasePath(): string
-    {
-        return __DIR__.'/../Resources/config/schema';
-    }
-
     public function getNamespace(): string
     {
         return 'http://www.sonata-project.org/schema/dic/formatter';
-    }
-
-    public function getAlias(): string
-    {
-        return 'sonata_formatter';
     }
 
     private function createEnvironment(): Definition

--- a/src/DependencyInjection/SonataFormatterExtension.php
+++ b/src/DependencyInjection/SonataFormatterExtension.php
@@ -76,10 +76,18 @@ final class SonataFormatterExtension extends Extension
             if (0 !== \count($formatterConfig['extensions'])) {
                 $envId = sprintf('sonata.formatter.twig.env.%s', $code);
 
-                $container->setDefinition(
-                    $envId,
-                    $this->createEnvironment()
-                );
+                $container->register($envId, Environment::class)
+                    ->setArguments([
+                        new Definition(LoaderSelector::class, [
+                            new Definition(ArrayLoader::class),
+                            new Reference('twig.loader'),
+                        ]),
+                        [
+                            'debug' => false,
+                            'strict_variables' => false,
+                            'charset' => 'UTF-8',
+                        ],
+                    ]);
 
                 $env = new Reference($envId);
             }
@@ -104,20 +112,5 @@ final class SonataFormatterExtension extends Extension
     public function getNamespace(): string
     {
         return 'http://www.sonata-project.org/schema/dic/formatter';
-    }
-
-    private function createEnvironment(): Definition
-    {
-        return new Definition(Environment::class, [
-            new Definition(LoaderSelector::class, [
-                new Definition(ArrayLoader::class),
-                new Reference('twig.loader'),
-            ]),
-            [
-                'debug' => false,
-                'strict_variables' => false,
-                'charset' => 'UTF-8',
-            ],
-        ]);
     }
 }

--- a/src/DependencyInjection/SonataFormatterExtension.php
+++ b/src/DependencyInjection/SonataFormatterExtension.php
@@ -24,7 +24,6 @@ use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Twig\Environment;
 use Twig\Extension\SandboxExtension;
-use Twig\Lexer;
 use Twig\Loader\ArrayLoader;
 
 /**
@@ -155,17 +154,6 @@ final class SonataFormatterExtension extends Extension
         $container->setDefinition(sprintf('sonata.formatter.twig.sandbox.%s', $code), $sandbox);
 
         $env->addMethodCall('addExtension', [new Reference(sprintf('sonata.formatter.twig.sandbox.%s', $code))]);
-
-        $lexer = new Definition(Lexer::class, [new Reference(sprintf('sonata.formatter.twig.env.%s', $code)), [
-            'tag_comment' => ['<#', '#>'],
-            'tag_block' => ['<%', '%>'],
-            'tag_variable' => ['<%=', '%>'],
-        ]]);
-        $lexer->setPublic(false);
-
-        $container->setDefinition(sprintf('sonata.formatter.twig.lexer.%s', $code), $lexer);
-
-        // $env->addMethodCall('setLexer', [new Reference(sprintf('sonata.formatter.twig.lexer.%s', $code))]);
 
         return sprintf('sonata.formatter.twig.env.%s', $code);
     }

--- a/src/DependencyInjection/SonataFormatterExtension.php
+++ b/src/DependencyInjection/SonataFormatterExtension.php
@@ -122,9 +122,6 @@ final class SonataFormatterExtension extends Extension
         string $code,
         array $extensions
     ): string {
-        $bundles = $container->getParameter('kernel.bundles');
-        \assert(\is_array($bundles));
-
         $loader = new Definition(ArrayLoader::class);
 
         $loader->setPublic(false);

--- a/src/Extension/BaseExtension.php
+++ b/src/Extension/BaseExtension.php
@@ -42,47 +42,6 @@ abstract class BaseExtension extends AbstractExtension implements ExtensionInter
         return [];
     }
 
-    public function getTokenParsers(): array
-    {
-        return [];
-    }
-
-    public function getNodeVisitors(): array
-    {
-        return [];
-    }
-
-    public function getFilters(): array
-    {
-        return [];
-    }
-
-    public function getTests(): array
-    {
-        return [];
-    }
-
-    public function getFunctions(): array
-    {
-        return [];
-    }
-
-    /**
-     * @return array{0?: array<string, array{precedence: int, class: class-string}>, 1?: array<string, array{precedence: int, class: class-string, associativity: int}>}
-     */
-    public function getOperators(): array
-    {
-        return [];
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    public function getGlobals(): array
-    {
-        return [];
-    }
-
     public static function getAllowedRuntimes(): array
     {
         return [];

--- a/src/Extension/BaseExtension.php
+++ b/src/Extension/BaseExtension.php
@@ -82,4 +82,9 @@ abstract class BaseExtension extends AbstractExtension implements ExtensionInter
     {
         return [];
     }
+
+    public static function getAllowedRuntimes(): array
+    {
+        return [];
+    }
 }

--- a/src/Extension/ExtensionInterface.php
+++ b/src/Extension/ExtensionInterface.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sonata\FormatterBundle\Extension;
 
+use Twig\Extension\RuntimeExtensionInterface;
+
 interface ExtensionInterface
 {
     /**
@@ -39,4 +41,9 @@ interface ExtensionInterface
      * @return array<class-string, array<string>>
      */
     public function getAllowedMethods(): array;
+
+    /**
+     * @return array<string, class-string<RuntimeExtensionInterface>>
+     */
+    public static function getAllowedRuntimes(): array;
 }

--- a/src/Extension/ExtensionInterface.php
+++ b/src/Extension/ExtensionInterface.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace Sonata\FormatterBundle\Extension;
 
-use Twig\Extension\RuntimeExtensionInterface;
-
 interface ExtensionInterface
 {
     /**
@@ -43,7 +41,11 @@ interface ExtensionInterface
     public function getAllowedMethods(): array;
 
     /**
-     * @return array<string, class-string<RuntimeExtensionInterface>>
+     * This allows Extensions to allow custom runtimes needed
+     * to execute Twig Extensions. Here you should return an array
+     * of the ids defined on the container.
+     *
+     * @return array<string>
      */
     public static function getAllowedRuntimes(): array;
 }

--- a/src/Extension/MediaExtension.php
+++ b/src/Extension/MediaExtension.php
@@ -45,4 +45,9 @@ final class MediaExtension extends BaseExtension
             'sonata_path',
         ];
     }
+
+    public static function getAllowedRuntimes(): array
+    {
+        return ['sonata.media.twig.runtime' => MediaRuntime::class];
+    }
 }

--- a/src/Extension/MediaExtension.php
+++ b/src/Extension/MediaExtension.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\FormatterBundle\Extension;
+
+use Sonata\MediaBundle\Model\MediaInterface;
+use Sonata\MediaBundle\Twig\MediaRuntime;
+use Twig\TwigFunction;
+
+final class MediaExtension extends BaseExtension
+{
+    public function getAllowedMethods(): array
+    {
+        return [
+            MediaInterface::class => [
+                'getProviderReference',
+            ],
+        ];
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('sonata_media', [MediaRuntime::class, 'media'], ['is_safe' => ['html']]),
+            new TwigFunction('sonata_thumbnail', [MediaRuntime::class, 'thumbnail'], ['is_safe' => ['html']]),
+            new TwigFunction('sonata_path', [MediaRuntime::class, 'path']),
+        ];
+    }
+
+    public function getAllowedFunctions(): array
+    {
+        return [
+            'sonata_media',
+            'sonata_thumbnail',
+            'sonata_path',
+        ];
+    }
+}

--- a/src/Extension/MediaExtension.php
+++ b/src/Extension/MediaExtension.php
@@ -48,6 +48,8 @@ final class MediaExtension extends BaseExtension
 
     public static function getAllowedRuntimes(): array
     {
-        return ['sonata.media.twig.runtime' => MediaRuntime::class];
+        return [
+            'sonata.media.twig.runtime',
+        ];
     }
 }

--- a/src/Resources/config/media.php
+++ b/src/Resources/config/media.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 use Psr\Container\ContainerInterface;
 use Sonata\FormatterBundle\Admin\CkeditorAdminExtension;
 use Sonata\FormatterBundle\Controller\CkeditorAdminController;
+use Sonata\FormatterBundle\Extension\MediaExtension;
 use Sonata\MediaBundle\Model\MediaManagerInterface;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ReferenceConfigurator;
@@ -30,5 +31,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->set('sonata.formatter.ckeditor.controller', CkeditorAdminController::class)
             ->public()
             ->tag('container.service_subscriber')
-            ->call('setContainer', [new ReferenceConfigurator(ContainerInterface::class)]);
+            ->call('setContainer', [new ReferenceConfigurator(ContainerInterface::class)])
+
+        ->set('sonata.formatter.twig.media', MediaExtension::class)
+            ->public();
 };

--- a/src/SonataFormatterBundle.php
+++ b/src/SonataFormatterBundle.php
@@ -13,8 +13,15 @@ declare(strict_types=1);
 
 namespace Sonata\FormatterBundle;
 
+use Sonata\FormatterBundle\DependencyInjection\Compiler\AddTwigExtensionsCompilerPass;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 final class SonataFormatterBundle extends Bundle
 {
+    public function build(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new AddTwigExtensionsCompilerPass());
+    }
 }

--- a/src/SonataFormatterBundle.php
+++ b/src/SonataFormatterBundle.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\FormatterBundle;
 
 use Sonata\FormatterBundle\DependencyInjection\Compiler\AddTwigExtensionsCompilerPass;
+use Sonata\FormatterBundle\DependencyInjection\Compiler\AddTwigLexerCompilerPass;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -22,6 +23,7 @@ final class SonataFormatterBundle extends Bundle
 {
     public function build(ContainerBuilder $container): void
     {
-        $container->addCompilerPass(new AddTwigExtensionsCompilerPass());
+        $container->addCompilerPass(new AddTwigExtensionsCompilerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 1);
+        $container->addCompilerPass(new AddTwigLexerCompilerPass());
     }
 }

--- a/tests/App/Resources/config/config.yaml
+++ b/tests/App/Resources/config/config.yaml
@@ -87,3 +87,4 @@ sonata_formatter:
             extensions:
                 - sonata.formatter.twig.control_flow
                 - sonata.formatter.twig.gist
+                - sonata.formatter.twig.media

--- a/tests/DependencyInjection/Compiler/AddTwigExtensionsCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddTwigExtensionsCompilerPassTest.php
@@ -25,7 +25,6 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 use Twig\Environment;
 use Twig\Extension\SandboxExtension;
-use Twig\RuntimeLoader\ContainerRuntimeLoader;
 
 /**
  * @author Jordi Sala <jordism91@gmail.com>
@@ -50,13 +49,6 @@ final class AddTwigExtensionsCompilerPassTest extends AbstractCompilerPassTestCa
         );
 
         $this->compile();
-
-        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
-            'sonata.formatter.twig.env.text',
-            'addExtension',
-            [
-            ]
-        );
     }
 
     public function testAddExtensionsToEnvironment(): void
@@ -112,14 +104,9 @@ final class AddTwigExtensionsCompilerPassTest extends AbstractCompilerPassTestCa
             2
         );
 
-        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
-            'sonata.formatter.twig.env.text',
-            'addRuntimeLoader',
-            [
-                new Definition(ContainerRuntimeLoader::class, [
-                    new Reference('.service_locator.HQ_PEHI'),
-                ]),
-            ]
+        static::assertTrue(
+            $this->container->getDefinition('sonata.formatter.twig.env.text')
+                ->hasMethodCall('addRuntimeLoader')
         );
     }
 

--- a/tests/DependencyInjection/Compiler/AddTwigExtensionsCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddTwigExtensionsCompilerPassTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\FormatterBundle\Tests\DependencyInjection\Compiler;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Sonata\FormatterBundle\DependencyInjection\Compiler\AddTwigExtensionsCompilerPass;
+use Sonata\FormatterBundle\Extension\GistExtension;
+use Sonata\FormatterBundle\Extension\MediaExtension;
+use Sonata\FormatterBundle\Formatter\Pool;
+use Sonata\FormatterBundle\Twig\SecurityPolicyContainerAware;
+use Sonata\MediaBundle\Twig\MediaRuntime;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+use Twig\Environment;
+use Twig\Extension\SandboxExtension;
+use Twig\RuntimeLoader\ContainerRuntimeLoader;
+
+/**
+ * @author Jordi Sala <jordism91@gmail.com>
+ */
+final class AddTwigExtensionsCompilerPassTest extends AbstractCompilerPassTestCase
+{
+    public function testAddNonExtensionsToFormatter(): void
+    {
+        $this->container->setParameter('sonata.formatter.configuration.formatters', [
+            'text' => [
+                'extensions' => [
+                    'random_service',
+                ],
+            ],
+        ]);
+        $this->container->register('sonata.formatter.twig.env.text', Environment::class);
+        $this->container->register('random_service', Pool::class);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Extension "random_service" added to formatter "text" do not implement Sonata\FormatterBundle\Extension\ExtensionInterface interface.'
+        );
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'sonata.formatter.twig.env.text',
+            'addExtension',
+            [
+            ]
+        );
+    }
+
+    public function testAddExtensionsToEnvironment(): void
+    {
+        $this->container->setParameter('sonata.formatter.configuration.formatters', [
+            'text' => [
+                'extensions' => [
+                    'sonata.formatter.twig.gist',
+                    'sonata.formatter.twig.media',
+                ],
+            ],
+        ]);
+        $this->container->register('sonata.formatter.twig.env.text', Environment::class);
+        $this->container->register('sonata.formatter.twig.gist', GistExtension::class);
+        $this->container->register('sonata.formatter.twig.media', MediaExtension::class);
+        $this->container->register('sonata.media.twig.runtime', MediaRuntime::class);
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'sonata.formatter.twig.env.text',
+            'addExtension',
+            [
+                new Definition(SandboxExtension::class, [
+                    new Definition(SecurityPolicyContainerAware::class, [
+                        new Reference('service_container'),
+                        [
+                            'sonata.formatter.twig.gist',
+                            'sonata.formatter.twig.media',
+                        ],
+                    ]),
+                    true,
+                ]),
+            ],
+            0
+        );
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'sonata.formatter.twig.env.text',
+            'addExtension',
+            [
+                new Reference('sonata.formatter.twig.gist'),
+            ],
+            1
+        );
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'sonata.formatter.twig.env.text',
+            'addExtension',
+            [
+                new Reference('sonata.formatter.twig.media'),
+            ],
+            2
+        );
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'sonata.formatter.twig.env.text',
+            'addRuntimeLoader',
+            [
+                new Definition(ContainerRuntimeLoader::class, [
+                    new Reference('.service_locator.HQ_PEHI'),
+                ]),
+            ]
+        );
+    }
+
+    protected function registerCompilerPass(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new AddTwigExtensionsCompilerPass());
+    }
+}

--- a/tests/DependencyInjection/Compiler/AddTwigLexerCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddTwigLexerCompilerPassTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\FormatterBundle\Tests\DependencyInjection\Compiler;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Sonata\FormatterBundle\DependencyInjection\Compiler\AddTwigLexerCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+use Twig\Environment;
+use Twig\Lexer;
+
+/**
+ * @author Jordi Sala <jordism91@gmail.com>
+ */
+final class AddTwigLexerCompilerPassTest extends AbstractCompilerPassTestCase
+{
+    public function testAddsLexerToTwigEnvironments(): void
+    {
+        $this->container->setParameter('sonata.formatter.configuration.formatters', [
+            'text' => []
+        ]);
+
+        $this->container->register('sonata.formatter.twig.env.text')
+            ->setClass(Environment::class);
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'sonata.formatter.twig.env.text',
+            'setLexer',
+            [
+                new Definition(Lexer::class, [
+                    new Reference('sonata.formatter.twig.env.text'),
+                    [
+                        'tag_comment' => ['<#', '#>'],
+                        'tag_block' => ['<%', '%>'],
+                        'tag_variable' => ['<%=', '%>'],
+                    ],
+                ]),
+            ]
+        );
+    }
+
+    protected function registerCompilerPass(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new AddTwigLexerCompilerPass());
+    }
+}

--- a/tests/DependencyInjection/Compiler/AddTwigLexerCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddTwigLexerCompilerPassTest.php
@@ -29,11 +29,9 @@ final class AddTwigLexerCompilerPassTest extends AbstractCompilerPassTestCase
     public function testAddsLexerToTwigEnvironments(): void
     {
         $this->container->setParameter('sonata.formatter.configuration.formatters', [
-            'text' => []
+            'text' => [],
         ]);
-
-        $this->container->register('sonata.formatter.twig.env.text')
-            ->setClass(Environment::class);
+        $this->container->register('sonata.formatter.twig.env.text', Environment::class);
 
         $this->compile();
 

--- a/tests/DependencyInjection/SonataFormatterExtensionTest.php
+++ b/tests/DependencyInjection/SonataFormatterExtensionTest.php
@@ -79,44 +79,6 @@ class SonataFormatterExtensionTest extends AbstractExtensionTestCase
         ]);
     }
 
-    // public function testItThrowsOnInvalidFormatterExtension(): void
-    // {
-    //     $this->setParameter('kernel.bundles', []);
-    //     $this->expectException(\InvalidArgumentException::class);
-    //     $this->expectExceptionMessage(
-    //         'You have requested a non-existent service "sonata.formatter.twig.random".'
-    //     );
-
-    //     $this->load([
-    //         'default_formatter' => 'text',
-    //         'formatters' => ['text' => [
-    //             'service' => 'sonata.formatter.text.text',
-    //             'extensions' => [
-    //                 'sonata.formatter.twig.random',
-    //             ],
-    //         ]],
-    //     ]);
-    // }
-
-    // public function testItThrowsOnExtensionThatIsNotAnExtension(): void
-    // {
-    //     $this->setParameter('kernel.bundles', []);
-    //     $this->expectException(\InvalidArgumentException::class);
-    //     $this->expectExceptionMessage(
-    //         'Extension "sonata.formatter.pool" added to formatter "text" do not implement Sonata\FormatterBundle\Extension\ExtensionInterface interface.'
-    //     );
-
-    //     $this->load([
-    //         'default_formatter' => 'text',
-    //         'formatters' => ['text' => [
-    //             'service' => 'sonata.formatter.text.text',
-    //             'extensions' => [
-    //                 'sonata.formatter.pool',
-    //             ],
-    //         ]],
-    //     ]);
-    // }
-
     /**
      * @return ExtensionInterface[]
      */

--- a/tests/DependencyInjection/SonataFormatterExtensionTest.php
+++ b/tests/DependencyInjection/SonataFormatterExtensionTest.php
@@ -80,43 +80,43 @@ class SonataFormatterExtensionTest extends AbstractExtensionTestCase
         ]);
     }
 
-    public function testItThrowsOnInvalidFormatterExtension(): void
-    {
-        $this->setParameter('kernel.bundles', []);
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
-            'You have requested a non-existent service "sonata.formatter.twig.random".'
-        );
+    // public function testItThrowsOnInvalidFormatterExtension(): void
+    // {
+    //     $this->setParameter('kernel.bundles', []);
+    //     $this->expectException(\InvalidArgumentException::class);
+    //     $this->expectExceptionMessage(
+    //         'You have requested a non-existent service "sonata.formatter.twig.random".'
+    //     );
 
-        $this->load([
-            'default_formatter' => 'text',
-            'formatters' => ['text' => [
-                'service' => 'sonata.formatter.text.text',
-                'extensions' => [
-                    'sonata.formatter.twig.random',
-                ],
-            ]],
-        ]);
-    }
+    //     $this->load([
+    //         'default_formatter' => 'text',
+    //         'formatters' => ['text' => [
+    //             'service' => 'sonata.formatter.text.text',
+    //             'extensions' => [
+    //                 'sonata.formatter.twig.random',
+    //             ],
+    //         ]],
+    //     ]);
+    // }
 
-    public function testItThrowsOnExtensionThatIsNotAnExtension(): void
-    {
-        $this->setParameter('kernel.bundles', []);
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
-            'Extension "sonata.formatter.pool" added to formatter "text" do not implement Sonata\FormatterBundle\Extension\ExtensionInterface interface.'
-        );
+    // public function testItThrowsOnExtensionThatIsNotAnExtension(): void
+    // {
+    //     $this->setParameter('kernel.bundles', []);
+    //     $this->expectException(\InvalidArgumentException::class);
+    //     $this->expectExceptionMessage(
+    //         'Extension "sonata.formatter.pool" added to formatter "text" do not implement Sonata\FormatterBundle\Extension\ExtensionInterface interface.'
+    //     );
 
-        $this->load([
-            'default_formatter' => 'text',
-            'formatters' => ['text' => [
-                'service' => 'sonata.formatter.text.text',
-                'extensions' => [
-                    'sonata.formatter.pool',
-                ],
-            ]],
-        ]);
-    }
+    //     $this->load([
+    //         'default_formatter' => 'text',
+    //         'formatters' => ['text' => [
+    //             'service' => 'sonata.formatter.text.text',
+    //             'extensions' => [
+    //                 'sonata.formatter.pool',
+    //             ],
+    //         ]],
+    //     ]);
+    // }
 
     public function testGetLoader(): void
     {

--- a/tests/DependencyInjection/SonataFormatterExtensionTest.php
+++ b/tests/DependencyInjection/SonataFormatterExtensionTest.php
@@ -16,7 +16,6 @@ namespace Sonata\FormatterBundle\Tests\DependencyInjection;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
 use Sonata\FormatterBundle\DependencyInjection\SonataFormatterExtension;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
-use Twig\Loader\LoaderInterface;
 
 class SonataFormatterExtensionTest extends AbstractExtensionTestCase
 {
@@ -117,16 +116,6 @@ class SonataFormatterExtensionTest extends AbstractExtensionTestCase
     //         ]],
     //     ]);
     // }
-
-    public function testGetLoader(): void
-    {
-        $this->setParameter('kernel.bundles', []);
-        $this->load();
-        static::assertInstanceOf(
-            LoaderInterface::class,
-            $this->container->get('sonata.formatter.twig.loader.text')
-        );
-    }
 
     /**
      * @return ExtensionInterface[]

--- a/tests/DependencyInjection/SonataFormatterExtensionTest.php
+++ b/tests/DependencyInjection/SonataFormatterExtensionTest.php
@@ -80,6 +80,44 @@ class SonataFormatterExtensionTest extends AbstractExtensionTestCase
         ]);
     }
 
+    public function testItThrowsOnInvalidFormatterExtension(): void
+    {
+        $this->setParameter('kernel.bundles', []);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'You have requested a non-existent service "sonata.formatter.twig.random".'
+        );
+
+        $this->load([
+            'default_formatter' => 'text',
+            'formatters' => ['text' => [
+                'service' => 'sonata.formatter.text.text',
+                'extensions' => [
+                    'sonata.formatter.twig.random',
+                ],
+            ]],
+        ]);
+    }
+
+    public function testItThrowsOnExtensionThatIsNotAnExtension(): void
+    {
+        $this->setParameter('kernel.bundles', []);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Extension "sonata.formatter.pool" added to formatter "text" do not implement Sonata\FormatterBundle\Extension\ExtensionInterface interface.'
+        );
+
+        $this->load([
+            'default_formatter' => 'text',
+            'formatters' => ['text' => [
+                'service' => 'sonata.formatter.text.text',
+                'extensions' => [
+                    'sonata.formatter.pool',
+                ],
+            ]],
+        ]);
+    }
+
     public function testGetLoader(): void
     {
         $this->setParameter('kernel.bundles', []);

--- a/tests/Functional/Admin/TextEntityAdminTest.php
+++ b/tests/Functional/Admin/TextEntityAdminTest.php
@@ -105,6 +105,14 @@ final class TextEntityAdminTest extends WebTestCase
             'textEntity[text][rawText]' => 'Sample Raw HTML with some <% for i in 1..5 %><% if i > 2 %><%= i %><% endif %><% endfor %>',
         ]];
 
+        yield 'Create TextEntity Raw HTML With Media' => ['/admin/tests/app/textentity/create', [
+            'uniqid' => 'textEntity',
+        ], 'btn_create_and_list', [
+            'textEntity[simpleText]' => 'simple text',
+            'textEntity[text][textFormat]' => 'rawhtml',
+            'textEntity[text][rawText]' => 'Sample Raw HTML with some <%= sonata_media(1, "reference") %>',
+        ]];
+
         yield 'Edit TextEntity' => ['/admin/tests/app/textentity/1/edit', [], 'btn_update_and_list'];
     }
 

--- a/tests/custom_bootstrap.php
+++ b/tests/custom_bootstrap.php
@@ -35,3 +35,9 @@ $input = new ArrayInput([
     'command' => 'doctrine:schema:create',
 ]);
 $application->run($input, new NullOutput());
+
+$input = new ArrayInput([
+    'command' => 'cache:clear',
+    '--no-warmup' => true,
+]);
+$application->run($input, new NullOutput());


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataFormatterBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is in preparation for 5.0.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataFormatterBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `MediaExtension` to render Media inside Formatters.
- Added ability to use Twig runtimes on your Formatter Extensions via `getAllowedRuntimes`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
