### PR TITLE
fix: change list_outer_rows_browser.html.twig template name.

### DIFF
--- a/src/Admin/CkeditorAdminExtension.php
+++ b/src/Admin/CkeditorAdminExtension.php
@@ -28,7 +28,7 @@ final class CkeditorAdminExtension extends AbstractAdminExtension
 {
     public function configure(AdminInterface $admin): void
     {
-        $admin->setTemplate('outer_list_rows_browser', '@SonataFormatter/Ckeditor/list_outer_rows_browser.html.twig');
+        $admin->setTemplate('outer_list_rows_list', '@SonataFormatter/Ckeditor/list_outer_rows_browser.html.twig');
     }
 
     public function configurePersistentParameters(AdminInterface $admin, array $parameters): array


### PR DESCRIPTION
## Subject

`outer_list_rows_browser` does not match any current template name in Sonata. With `outer_list_rows_list` instead, the
[list_outer_rows_browser.html.twig](https://github.com/sonata-project/SonataFormatterBundle/blob/5.x/src/Resources/views/Ckeditor/list_outer_rows_browser.html.twig) template is used and the javascript in [browser.html.twig](https://github.com/sonata-project/SonataFormatterBundle/blob/5.x/src/Resources/views/Ckeditor/browser.html.twig) is working again (we can select images by clicking on them).

I am targeting this branch, because it is a BC fix.


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataFormatterBundle/releases,
    please keep it short and clear and to the point
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fix wrong template name preventing users to select images.
```