### PR TITLE
Fix BlockService to work with current Form

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "phpunit/phpunit": "^9.5",
         "psalm/plugin-phpunit": "^0.17",
         "psalm/plugin-symfony": "^3.1",
-        "rector/rector": "^0.13",
+        "rector/rector": "^0.14",
         "sonata-project/admin-bundle": "^4.0",
         "sonata-project/classification-bundle": "^4.0",
         "sonata-project/doctrine-extensions": "^1.0 || ^2.0",

--- a/src/Block/FormatterBlockService.php
+++ b/src/Block/FormatterBlockService.php
@@ -48,9 +48,8 @@ final class FormatterBlockService extends AbstractBlockService implements Editab
         $form->add('settings', ImmutableArrayType::class, [
             'keys' => [
                 ['content', FormatterType::class, static fn (FormBuilderInterface $formBuilder) => [
-                    'event_dispatcher' => $formBuilder->getEventDispatcher(),
-                    'format_field' => ['format', '[format]'],
-                    'source_field' => ['rawContent', '[rawContent]'],
+                    'format_field' => 'format',
+                    'source_field' => 'rawContent',
                     'target_field' => '[content]',
                     'label' => 'form.label_content',
                 ]],

--- a/src/Block/FormatterBlockService.php
+++ b/src/Block/FormatterBlockService.php
@@ -47,7 +47,7 @@ final class FormatterBlockService extends AbstractBlockService implements Editab
     {
         $form->add('settings', ImmutableArrayType::class, [
             'keys' => [
-                ['content', FormatterType::class, static fn (FormBuilderInterface $formBuilder) => [
+                ['content', FormatterType::class, [
                     'format_field' => 'format',
                     'source_field' => 'rawContent',
                     'target_field' => '[content]',

--- a/src/Block/FormatterBlockService.php
+++ b/src/Block/FormatterBlockService.php
@@ -23,7 +23,6 @@ use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\Form\Type\ImmutableArrayType;
 use Sonata\Form\Validator\ErrorElement;
 use Sonata\FormatterBundle\Form\Type\FormatterType;
-use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 5.x is for everything backwards compatible, like patches, features and deprecation notices
    - 6.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataFormatterBundle/blob/5.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because {reason}.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #{put_issue_number_here}.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataFormatterBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fix FormatterBlockService to work with current form.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
