### PR TITLE
Use PRE_SUBMIT since SUBMIT is not dispatched when inherit_data is set to true

### DIFF
--- a/src/Block/FormatterBlockService.php
+++ b/src/Block/FormatterBlockService.php
@@ -49,7 +49,7 @@ final class FormatterBlockService extends AbstractBlockService implements Editab
                 ['content', FormatterType::class, [
                     'format_field' => 'format',
                     'source_field' => 'rawContent',
-                    'target_field' => '[content]',
+                    'target_field' => 'content',
                     'label' => 'form.label_content',
                 ]],
             ],

--- a/src/Block/FormatterBlockService.php
+++ b/src/Block/FormatterBlockService.php
@@ -51,6 +51,7 @@ final class FormatterBlockService extends AbstractBlockService implements Editab
                     'source_field' => 'rawContent',
                     'target_field' => 'content',
                     'label' => 'form.label_content',
+                    'translation_domain' => 'SonataFormatterBundle',
                 ]],
             ],
             'translation_domain' => 'SonataFormatterBundle',

--- a/src/Form/EventListener/FormatterListener.php
+++ b/src/Form/EventListener/FormatterListener.php
@@ -15,7 +15,6 @@ namespace Sonata\FormatterBundle\Form\EventListener;
 
 use Sonata\FormatterBundle\Formatter\PoolInterface;
 use Symfony\Component\Form\FormEvent;
-use Symfony\Component\PropertyAccess\PropertyAccess;
 
 final class FormatterListener
 {

--- a/src/Form/EventListener/FormatterListener.php
+++ b/src/Form/EventListener/FormatterListener.php
@@ -38,19 +38,18 @@ final class FormatterListener
 
     public function postSubmit(FormEvent $event): void
     {
-        $accessor = PropertyAccess::createPropertyAccessor();
-
-        $format = $accessor->getValue($event->getData(), $this->formatField);
-        $source = $accessor->getValue($event->getData(), $this->sourceField);
-
-        // make sure the listener works with array
         $data = $event->getData();
 
-        $accessor->setValue(
-            $data,
-            $this->targetField,
-            \is_string($source) ? $this->pool->transform($format, $source) : null
-        );
+        if (!\is_array($data)) {
+            return;
+        }
+
+        $source = $data[$this->sourceField] ?? null;
+        $format = $data[$this->formatField] ?? null;
+
+        $data[$this->targetField] = null !== $source && null !== $format ?
+            $this->pool->transform($format, $source) :
+            null;
 
         $event->setData($data);
     }

--- a/src/Form/Type/FormatterType.php
+++ b/src/Form/Type/FormatterType.php
@@ -75,7 +75,7 @@ final class FormatterType extends AbstractType
                 $options['target_field']
             );
 
-            $builder->addEventListener(FormEvents::SUBMIT, [$listener, 'postSubmit']);
+            $builder->addEventListener(FormEvents::PRE_SUBMIT, [$listener, 'postSubmit']);
         }
     }
 

--- a/src/Form/Type/FormatterType.php
+++ b/src/Form/Type/FormatterType.php
@@ -61,18 +61,24 @@ final class FormatterType extends AbstractType
             $formatOptions['choice_translation_domain'] = 'SonataFormatterBundle';
         }
 
+        $sourceOptions = $options['source_field_options'];
+
         $builder->add($formatField, $formatType, $formatOptions);
-        $builder->add($sourceField, TextareaType::class, $options['source_field_options']);
+        $builder->add($sourceField, TextareaType::class, $sourceOptions);
 
         /*
          * The listener option only work if the source field is after the current field
          */
         if (true === $options['listener']) {
+            $targetField = $options['target_field'];
+
+            $builder->add($targetField, HiddenType::class);
+
             $listener = new FormatterListener(
                 $this->pool,
-                $formatOptions['property_path'] ?? $formatField,
-                $options['source_field_options']['property_path'] ?? $sourceField,
-                $options['target_field']
+                $formatField,
+                $sourceField,
+                $targetField
             );
 
             $builder->addEventListener(FormEvents::PRE_SUBMIT, [$listener, 'postSubmit']);

--- a/tests/Form/EventListener/FormatterListenerTest.php
+++ b/tests/Form/EventListener/FormatterListenerTest.php
@@ -29,7 +29,7 @@ class FormatterListenerTest extends TestCase
 
         $pool = $this->getPool();
 
-        $listener = new FormatterListener($pool, '[format]', '[source]', '[target]');
+        $listener = new FormatterListener($pool, 'format', 'source', 'target');
 
         $event = new FormEvent($this->createMock(FormInterface::class), [
             'format' => 'error',
@@ -50,7 +50,7 @@ class FormatterListenerTest extends TestCase
         $pool = $this->getPool();
         $pool->add('myformat', $formatter);
 
-        $listener = new FormatterListener($pool, '[format]', '[source]', '[target]');
+        $listener = new FormatterListener($pool, 'format', 'source', 'target');
 
         $event = new FormEvent($this->createMock(FormInterface::class), [
             'format' => 'myformat',

--- a/tests/Form/Type/FormatterTypeTest.php
+++ b/tests/Form/Type/FormatterTypeTest.php
@@ -140,13 +140,13 @@ final class FormatterTypeTest extends TypeTestCase
                 'target_field' => 'text',
             ]);
 
-        $listeners = $formBuilder->get('text')->getEventDispatcher()->getListeners(FormEvents::SUBMIT);
+        $listeners = $formBuilder->get('text')->getEventDispatcher()->getListeners(FormEvents::PRE_SUBMIT);
 
-        static::assertCount(1, $listeners);
-        static::assertIsArray($listeners[0]);
-        static::assertCount(2, $listeners[0]);
-        static::assertInstanceOf(FormatterListener::class, $listeners[0][0]);
-        static::assertSame('postSubmit', $listeners[0][1]);
+        static::assertCount(2, $listeners);
+        static::assertIsArray($listeners[1]);
+        static::assertCount(2, $listeners[1]);
+        static::assertInstanceOf(FormatterListener::class, $listeners[1][0]);
+        static::assertSame('postSubmit', $listeners[1][1]);
     }
 
     public function testWithPropertyPaths(): void


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 5.x is for everything backwards compatible, like patches, features and deprecation notices
    - 6.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataFormatterBundle/blob/5.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because fixes a bug with the formatter type.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #715 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataFormatterBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fix `FormatterType` listener option, now it should update `target_field` when listener is set to "true" (its default value).
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
