### PR TITLE
Drop PHP 7.4, up DAMA to v7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "homepage": "https://docs.sonata-project.org/projects/SonataFormatterBundle",
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "friendsofsymfony/ckeditor-bundle": "^2.0",
         "psr/container": "^1.0 || ^2.0",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
@@ -42,7 +42,7 @@
         "twig/twig": "^2.12.1 || ^3.0"
     },
     "require-dev": {
-        "dama/doctrine-test-bundle": "^6.7",
+        "dama/doctrine-test-bundle": "^7.0",
         "doctrine/doctrine-bundle": "^2.7",
         "doctrine/orm": "^2.14",
         "friendsofphp/php-cs-fixer": "^3.4",


### PR DESCRIPTION

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 5.x is for everything backwards compatible, like patches, features and deprecation notices
    - 6.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataFormatterBundle/blob/5.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is Bc.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataFormatterBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Drop support for PHP 7.4
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
